### PR TITLE
Update the `ks.pkrtpl.hcl` for VMware Photon OS

### DIFF
--- a/builds/linux/photon-4/data/ks.pkrtpl.hcl
+++ b/builds/linux/photon-4/data/ks.pkrtpl.hcl
@@ -24,6 +24,7 @@
         "#!/bin/sh",
         "useradd -m -p '${build_password_encrypted}' -s /bin/bash ${build_username}",
         "usermod -aG sudo ${build_username}",
+        "echo \"${build_username} ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers.d/${build_username}",
         "chage -I -1 -m 0 -M 99999 -E -1 root",
         "chage -I -1 -m 0 -M 99999 -E -1 ${build_username}",
         "iptables -A INPUT -p tcp --dport 22 -j ACCEPT",
@@ -31,8 +32,8 @@
         "iptables -A OUTPUT -p ICMP -j ACCEPT",
         "iptables-save > /etc/systemd/scripts/ip4save",
         "systemctl restart iptables",
-        "sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
-        "sed -i 's/MaxAuthTries.*/MaxAuthTries 10/g' /etc/ssh/sshd_config",
+        "sed -i 's/.*PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config",
+        "sed -i 's/.*MaxAuthTries.*/MaxAuthTries 10/g' /etc/ssh/sshd_config",
         "systemctl restart sshd.service"
     ],
     "install_linux_esx": true,


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Update the `kt.pkrtpl.hcl` for VMware Photon OS.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Add missing command to add `build_username` to password-less sudoers.
- Update the `sed` commands to be more accurate.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
