### PR TITLE
Add support for VMware Photon OS 4.0 Rev1

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The files are distributed in the following directories.
 
     **Linux Distributions**
     * VMware Photon OS 4 Server
-        * [Download][download-linux-photon-server-4] the 4.0 GA release of the **FULL** `.iso` image. (_e.g._ `photon-4.0-1526e30ba.iso`)
+        * [Download][download-linux-photon-server-4] the 4.0 GA release of the **FULL** `.iso` image. (_e.g._ `photon-4.0-ca7c9e933.iso`)
     * Ubuntu Server 20.04 LTS
         * [Download][download-linux-ubuntu-server-20-04-lts] the latest **LIVE** release `.iso` image. (_e.g._ `ubuntu-20.04.2-live-server-amd64.iso`)
     * Ubuntu Server 18.04 LTS
@@ -205,9 +205,9 @@ The files are distributed in the following directories.
     **Example**: `config/common.pkvars.hcl`
     ```
     iso_path           = "iso/linux/photon"
-    iso_file           = "photon-4.0-1526e30ba.iso"
+    iso_file           = "photon-4.0-ca7c9e933.iso"
     iso_checksum_type  = "md5"
-    iso_checksum_value = "e0c77e9495c7bfaea20cc17be3cb145b"
+    iso_checksum_value = "d8c4bc561e68afaf7815518f78a5b4ab"
     ```
 
 ### Step 3 - Configure Service Account Privileges in vSphere 

--- a/ansible/roles/base/tasks/photon.yml
+++ b/ansible/roles/base/tasks/photon.yml
@@ -8,13 +8,6 @@
 - name: "{{ ansible_facts['distribution'] }} - Updating the guest operating system."
   command: "{{item}}"
   with_items:
-    ### ----------------------------------------------- ###
-    ### Required due to a bug in VMware Photon OS 4.0.  ###
-    - tdnf -y remove minimal
-    - rpm -e --noscripts systemd-udev-247.3-1.ph4
-    ### ----------------------------------------------- ###
-    - tdnf clean all
-    - tdnf makecache
     - tdnf -y update
   args:
     warn: false

--- a/builds/linux/photon-4/data/ks.pkrtpl.hcl
+++ b/builds/linux/photon-4/data/ks.pkrtpl.hcl
@@ -13,8 +13,10 @@
         {"size": 128, "filesystem": "swap"}
     ],
     "bootmode": "efi",
-    "packagelist_file": "packages_minimal.json",
-    "additional_packages": [
+    "packages": [
+        "minimal",
+        "linux",
+        "initramfs",
         "sudo",
         "vim",
         "cloud-utils",
@@ -27,16 +29,12 @@
         "echo \"${build_username} ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers.d/${build_username}",
         "chage -I -1 -m 0 -M 99999 -E -1 root",
         "chage -I -1 -m 0 -M 99999 -E -1 ${build_username}",
-        "iptables -A INPUT -p tcp --dport 22 -j ACCEPT",
-        "iptables -A INPUT -p ICMP -j ACCEPT",
-        "iptables -A OUTPUT -p ICMP -j ACCEPT",
-        "iptables-save > /etc/systemd/scripts/ip4save",
         "systemctl restart iptables",
         "sed -i 's/.*PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config",
         "sed -i 's/.*MaxAuthTries.*/MaxAuthTries 10/g' /etc/ssh/sshd_config",
         "systemctl restart sshd.service"
     ],
-    "install_linux_esx": true,
+    "linux_flavor": "linux",
     "network": {
         "type": "dhcp"
     }

--- a/builds/linux/photon-4/data/packages_minimal.json
+++ b/builds/linux/photon-4/data/packages_minimal.json
@@ -1,7 +1,0 @@
-{
-    "packages": [
-        "minimal",
-        "linux-esx",
-        "initramfs"
-        ]
-}

--- a/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon-4/linux-photon.auto.pkrvars.hcl
@@ -27,9 +27,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/photon"
-iso_file           = "photon-4.0-1526e30ba.iso"
+iso_file           = "photon-4.0-ca7c9e933.iso"
 iso_checksum_type  = "md5"
-iso_checksum_value = "e0c77e9495c7bfaea20cc17be3cb145b"
+iso_checksum_value = "d8c4bc561e68afaf7815518f78a5b4ab"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/linux/photon-4/linux-photon.pkr.hcl
+++ b/builds/linux/photon-4/linux-photon.pkr.hcl
@@ -74,7 +74,6 @@ source "vsphere-iso" "linux-photon" {
       build_username           = var.build_username
       build_password_encrypted = var.build_password_encrypted
     })
-    "/packages.json" = file("${abspath(path.root)}/data/packages_minimal.json")
   }
 
   // Boot and Provisioning Settings


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Adds support for VMware Photon OS 4.0 Rev1.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Adds VMware Photon OS 4.0 Rev1 file/checksum to `.pkvars.hcl`.
- Sets the `linux-flavor` to `linux` vs `esx` in `ks.pkrtpl.hcl`.
   See VMware Photon Installer[ kickstart reference](https://github.com/vmware/photon-os-installer/blob/master/photon_installer/ks_config.txt).
- Simplifies to `packages` in `ks.pkrtpl.hcl` and only a ks.json for the build `http_content`.
- Removes iptables changes in `ks.pkrtpl.hcl`.
- Removes the need to remove/install `minimal` as seen in 4.0 GA.
- Updates README.md.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Fixes: #94 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [X] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
