### PR TITLE
Set host keys to generate on first-boot

### DIFF
--- a/scripts/linux/photon.sh
+++ b/scripts/linux/photon.sh
@@ -90,7 +90,7 @@ rm -rf /var/tmp/*
 
 # Cleans SSH keys.
 echo '> Cleaning SSH keys ...'
-#rm -f /etc/ssh/ssh_host_*
+rm -f /etc/ssh/ssh_host_*
 
 # Sets hostname to localhost.
 echo '> Setting hostname to localhost ...'

--- a/scripts/linux/rhel7-derivative.sh
+++ b/scripts/linux/rhel7-derivative.sh
@@ -121,9 +121,5 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 
-### Generate the host keys using ssh-keygen. ### 
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
-
 ### Done. ### 
 echo '> Done.'

--- a/scripts/linux/rhel7.sh
+++ b/scripts/linux/rhel7.sh
@@ -89,7 +89,7 @@ rm -rf /var/cache/dnf/*
 
 ### Clean the SSH keys. ###
 echo '> Cleaning the SSH keys ...'
-#rm -f /etc/ssh/ssh_host_*
+rm -f /etc/ssh/ssh_host_*
 
 ### Sets the hostname to localhost. ###
 echo '> Setting the hostname to localhost ...'
@@ -127,10 +127,6 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 ### END: Clean the guest operating system. ###
-
-### Generate the host keys using ssh-keygen. ###
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
 
 ### Done. ###
 echo '> Done.'

--- a/scripts/linux/rhel8-derivative.sh
+++ b/scripts/linux/rhel8-derivative.sh
@@ -121,9 +121,5 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 
-### Generate the host keys using ssh-keygen. ### 
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
-
 ### Done. ### 
 echo '> Done.'

--- a/scripts/linux/rhel8.sh
+++ b/scripts/linux/rhel8.sh
@@ -89,7 +89,7 @@ rm -rf /var/cache/dnf/*
 
 ### Clean the SSH keys. ###
 echo '> Cleaning the SSH keys ...'
-#rm -f /etc/ssh/ssh_host_*
+rm -f /etc/ssh/ssh_host_*
 
 ### Sets the hostname to localhost. ###
 echo '> Setting the hostname to localhost ...'
@@ -127,10 +127,6 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 ### END: Clean the guest operating system. ###
-
-### Generate the host keys using ssh-keygen. ###
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
 
 ### Done. ###
 echo '> Done.'

--- a/scripts/linux/ubuntu-server-18.sh
+++ b/scripts/linux/ubuntu-server-18.sh
@@ -117,9 +117,14 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 
-### Generate the host keys using ssh-keygen. ###
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
+### Set check for ssh keys on reboot; regenerate on reboot if neccessary. ###
+echo '> Setting check for ssh keys on reboot; will regenerate on reboot if neccessary. ...'
+sudo cat <<EOF > /etc/rc.local
+#!/bin/bash
+test -f /etc/ssh/ssh_host_dsa_key || dpkg-reconfigure openssh-server
+exit 0
+EOF
+sudo chmod +x /etc/rc.local
 
 ### Done. ###
 echo '> Done.'

--- a/scripts/linux/ubuntu-server-2x.sh
+++ b/scripts/linux/ubuntu-server-2x.sh
@@ -124,9 +124,14 @@ sudo chmod +x /home/$BUILD_USERNAME/clean.sh
 echo '> Running the clean script ...'
 sudo /home/$BUILD_USERNAME/clean.sh
 
-### Generate the host keys using ssh-keygen. ###
-echo '> Generating the host keys using ssh-keygen ...'
-sudo ssh-keygen -A
+### Set check for ssh keys on reboot; regenerate on reboot if neccessary. ###
+echo '> Setting check for ssh keys on reboot; will regenerate on reboot if neccessary. ...'
+sudo cat <<EOF > /etc/rc.local
+#!/bin/bash
+test -f /etc/ssh/ssh_host_dsa_key || dpkg-reconfigure openssh-server
+exit 0
+EOF
+sudo chmod +x /etc/rc.local
 
 ### Done. ###
 echo '> Done.'


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Addressing an issue noticed by @markpeek.

Changes ensure the host keys are cleaned and are generated on the first-boot for uniqueness.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- For RHEL/RHEL derivative and Photon OS the host keys are removed during cleanup (`rm -f /etc/ssh/ssh_host_*`) and automatically, by default, are regenerated on the first-boot.

- For Ubuntu, the host keys are removed during cleanup (`rm -f /etc/ssh/ssh_host_*`) and an `/etc/rc.local` is added to regenerate on first-boot. Later, if the host keys are missing for any reason, they will be regenerated on reboot. If present, no action.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
