### PR TITLE
Add support for `skip_import` to the content library

### DIFF
--- a/builds/common.pkrvars.hcl.example
+++ b/builds/common.pkrvars.hcl.example
@@ -10,10 +10,11 @@ common_tools_upgrade_policy = true
 common_remove_cdrom         = true
 
 // Template and Content Library Settings
-common_template_conversion     = false
-common_content_library_name    = "sfo-w01-lib01"
-common_content_library_ovf     = true
-common_content_library_destroy = true
+common_template_conversion         = false
+common_content_library_name        = "sfo-w01-lib01"
+common_content_library_ovf         = true
+common_content_library_destroy     = true
+common_content_library_skip_import = false
 
 // Removable Media Settings
 common_iso_datastore = "sfo-w01-cl01-ds-nfs01"

--- a/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux-8/linux-almalinux.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "linux-almalinux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/almalinux-8/variables.pkr.hcl
+++ b/builds/linux/almalinux-8/variables.pkr.hcl
@@ -204,8 +204,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/linux/centos-linux-7/linux-centos-linux.pkr.hcl
+++ b/builds/linux/centos-linux-7/linux-centos-linux.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "linux-centos-linux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/centos-linux-7/variables.pkr.hcl
+++ b/builds/linux/centos-linux-7/variables.pkr.hcl
@@ -204,8 +204,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
+++ b/builds/linux/centos-linux-8/linux-centos-linux.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "linux-centos-linux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/centos-linux-8/variables.pkr.hcl
+++ b/builds/linux/centos-linux-8/variables.pkr.hcl
@@ -204,8 +204,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos-stream-8/linux-centos-stream.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "linux-centos-stream" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/centos-stream-8/variables.pkr.hcl
+++ b/builds/linux/centos-stream-8/variables.pkr.hcl
@@ -204,8 +204,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/linux/photon-4/linux-photon.pkr.hcl
+++ b/builds/linux/photon-4/linux-photon.pkr.hcl
@@ -110,9 +110,10 @@ source "vsphere-iso" "linux-photon" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/photon-4/variables.pkr.hcl
+++ b/builds/linux/photon-4/variables.pkr.hcl
@@ -190,6 +190,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/linux/redhat-linux-7/linux-redhat-linux.pkr.hcl
+++ b/builds/linux/redhat-linux-7/linux-redhat-linux.pkr.hcl
@@ -117,9 +117,10 @@ source "vsphere-iso" "linux-redhat-linux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/redhat-linux-7/variables.pkr.hcl
+++ b/builds/linux/redhat-linux-7/variables.pkr.hcl
@@ -222,6 +222,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
+++ b/builds/linux/redhat-linux-8/linux-redhat-linux.pkr.hcl
@@ -117,9 +117,10 @@ source "vsphere-iso" "linux-redhat-linux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/redhat-linux-8/variables.pkr.hcl
+++ b/builds/linux/redhat-linux-8/variables.pkr.hcl
@@ -222,6 +222,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
+++ b/builds/linux/rocky-linux-8/linux-rocky-linux.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "linux-rocky-linux" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/rocky-linux-8/variables.pkr.hcl
+++ b/builds/linux/rocky-linux-8/variables.pkr.hcl
@@ -208,6 +208,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/linux-ubuntu-server.pkr.hcl
@@ -124,9 +124,10 @@ source "vsphere-iso" "linux-ubuntu-server" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-18-04-lts/variables.pkr.hcl
@@ -208,6 +208,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/linux-ubuntu-server.pkr.hcl
@@ -119,9 +119,10 @@ source "vsphere-iso" "linux-ubuntu-server" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu-server-20-04-lts/variables.pkr.hcl
@@ -208,6 +208,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/windows/windows-10/variables.pkr.hcl
+++ b/builds/windows/windows-10/variables.pkr.hcl
@@ -213,8 +213,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/windows/windows-10/windows.pkr.hcl
+++ b/builds/windows/windows-10/windows.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "windows-10-professional" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/windows/windows-11/variables.pkr.hcl
+++ b/builds/windows/windows-11/variables.pkr.hcl
@@ -213,8 +213,14 @@ variable "common_content_library_ovf" {
 
 variable "common_content_library_destroy" {
   type        = bool
-  description = "Delete the virtual machine afer exporting to the content library."
+  description = "Delete the virtual machine after exporting to the content library."
   default     = true
+}
+
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
 }
 
 // Removable Media Settings

--- a/builds/windows/windows-11/windows.pkr.hcl
+++ b/builds/windows/windows-11/windows.pkr.hcl
@@ -115,9 +115,10 @@ source "vsphere-iso" "windows-11-professional" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/windows/windows-server-2016/variables.pkr.hcl
+++ b/builds/windows/windows-server-2016/variables.pkr.hcl
@@ -232,6 +232,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/windows/windows-server-2016/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2016/windows-server.pkr.hcl
@@ -113,9 +113,10 @@ source "vsphere-iso" "windows-server-standard-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -199,9 +200,10 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -286,9 +288,10 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -373,9 +376,10 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/windows/windows-server-2019/variables.pkr.hcl
+++ b/builds/windows/windows-server-2019/variables.pkr.hcl
@@ -232,6 +232,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/windows/windows-server-2019/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2019/windows-server.pkr.hcl
@@ -113,9 +113,10 @@ source "vsphere-iso" "windows-server-standard-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -200,9 +201,10 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -287,9 +289,10 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -374,9 +377,10 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }

--- a/builds/windows/windows-server-2022/variables.pkr.hcl
+++ b/builds/windows/windows-server-2022/variables.pkr.hcl
@@ -232,6 +232,12 @@ variable "common_content_library_destroy" {
   default     = true
 }
 
+variable "common_content_library_skip_import" {
+  type        = bool
+  description = "Skip exporting the virtual machine to the content library. Option allows for testing / debugging without saving the machine image."
+  default     = false
+}
+
 // Removable Media Settings
 
 variable "common_iso_datastore" {

--- a/builds/windows/windows-server-2022/windows-server.pkr.hcl
+++ b/builds/windows/windows-server-2022/windows-server.pkr.hcl
@@ -113,9 +113,10 @@ source "vsphere-iso" "windows-server-standard-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -200,9 +201,10 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -287,9 +289,10 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }
@@ -374,9 +377,10 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   dynamic "content_library_destination" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
-      library = var.common_content_library_name
-      ovf     = var.common_content_library_ovf
-      destroy = var.common_content_library_destroy
+      library     = var.common_content_library_name
+      ovf         = var.common_content_library_ovf
+      destroy     = var.common_content_library_destroy
+      skip_import = var.common_content_library_skip_import
     }
   }
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Adds support for `skip_import` added to `packer-plugin-vsphere` in `v1.0.2`.  

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [X] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

- Adds support for `skip_import` added to `packer-plugin-vsphere` in `v1.0.2`.  
- When set to `true` the virtual machine will not be imported into the content library. 
- Useful for testing / debugging. 
- Defaults to `false`.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
