### PR TITLE
fix: :wrench: Correct `boot_command` for RHEL and derivatives

### DIFF
--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -91,7 +91,7 @@ source "vsphere-iso" "linux-almalinux" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -91,7 +91,7 @@ source "vsphere-iso" "linux-centos" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -91,7 +91,7 @@ source "vsphere-iso" "linux-centos-stream" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/centos/8/linux-centos.pkr.hcl
+++ b/builds/linux/centos/8/linux-centos.pkr.hcl
@@ -91,7 +91,7 @@ source "vsphere-iso" "linux-centos" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -93,7 +93,7 @@ source "vsphere-iso" "linux-rhel" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -93,7 +93,7 @@ source "vsphere-iso" "linux-rhel" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -91,7 +91,7 @@ source "vsphere-iso" "linux-rocky" {
   boot_order    = var.vm_boot_order
   boot_wait     = var.vm_boot_wait
   boot_command = [
-    "up",
+    "<up>",
     "e",
     "<down><down><end><wait>",
     "text ${local.data_source_command}",


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

## Summary of Pull Request

Updates `"up"` to `"<up"` in the `boot_command` for RHEL and derivatives. #178
## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes #178

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "x".
-->

- [X] Tests have been completed (for bugfixes / features).
- [X] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
