### PR TITLE
bug: Fix `iso_checksum_value` value

### DIFF
--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -45,7 +45,7 @@ vm_network_card          = "vmxnet3"
 iso_path           = "iso/windows/server"
 iso_file           = "en-us_windows_server_2022_updated_jan_2022_x64_dvd_f7ca3012.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "6BCE87FD4A0E4FE858E4FAB97290C8C51F0F65A016ACA8A8C80902470B90F121"
+iso_checksum_value = "662366CB186381ABDA2D326BB4A6CFD383F5924B35CB3A3797DC712C3208EC8D"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

## Summary of Pull Request

Fixes the `iso_checksum_value` value for Windows Server 2022

## Type of Pull Request

- [x] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bugfixes / features).
- [ ] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
