### PR TITLE
chore: Update OS and dependency versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -64,7 +64,7 @@ body:
       description: >-
         Please provide the HashiCorp Packer Plugin for VMware vSphere Version
         version.
-      placeholder: 1.0.3
+      placeholder: 1.0.4
     validations:
       required: true
   - type: input

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,3 +25,4 @@ jobs:
           DISABLE_ERRORS: false
           VALIDATE_ANSIBLE: false
           VALIDATE_TERRAGRUNT: false
+          VALIDATE_MARKDOWN: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,39 @@
 # CHANGELOG
 
-## v22.04
+## [Unreleased](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/unreleased)
+
+> Release Date: Unreleased
+
+🧹 **Chore**:
+
+* Updates Red Hat Enterprise Linux 8 .iso and checksum to 8.6 release.
+* Updates Rocky Linux 8 .iso and checksum to 8.6 release.
+* Updates Almalinux 8 .iso and checksum to 8.6 release.
+* Updates CentOS Stream 8 checksum to latest release.
+* Updates Windows Server 2022 .iso and checksum to April 2022 release.
+* Updates Windows Server 11 .iso and checksum to May 2022 release.
+* Updates `required_plugins` for `packer-plugin-vsphere` to `>= v1.0.4`.
+* Updates `required_plugins` and `packer-plugin-windows-update` to `>= v0.14.1`.
+
+## [v22.04](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v22.04)
 
 > Release Date: 2022-04-28
 
 💫  **Enhancement**:
+
 * Adds Ubuntu Server 22.04 LTS (GH-185)
 * Adds an option to generate a custom build script. (GH-188)
 
 🐞 **Bugfix**:
+
 * Updates the Python interpreter for Ansible on AlmaLinux to use `/usr/libexec/platform-python`. (GH-182)
 * Adds the use of `build_password` to the Linux distributions to ensure use of `set-envvars.sh` works as expected. (GH-197)
-* Updates the SHA256 checksum for the CentOS 7 ISO `CentOS-7-x86_64-DVD-2009.iso` (GH-201)
+* Updates the SHA256 checksum for the CentOS 7 .iso `CentOS-7-x86_64-DVD-2009.iso`. (GH-201)
 
 🧹 **Chore**:
+
 * Updates the Windows Server 2022 .iso to February 2022 release. (GH-192)
-* Updates the Ubuntu 20.04 LTS .iso to `v20.04.4`. (GH-184)
+* Updates the Ubuntu 20.04 LTS .iso to 20.04.4 release. (GH-184)
 
 ## [v22.03](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v22.03)
 
@@ -97,15 +115,20 @@
     common_content_library_ovf     = false
     common_content_library_destroy = false
     ```
+
 * Adds support for a SOCKS proxy by editing `config/proxy.pkvars.hcl`.
 * Adds the ability to set the IP address to bind the HTTP server by editing the `common_http_ip` in `config/common.pkvars.hcl` from `null` to an IP address on the Packer host:
+
     ```hcl
     common_http_ip = "172.16.11.100"
     ```
+
 * Add configurable data source provisioning for Linux images. By default, HTTP is used for the kickstart. By editing the `common_data_source` in `config/common.pkvars.hcl` from `http` to `disk` the build will use a disk-based method, such as a `.iso` as the secondary CD-ROM. This is useful for environments that can not communicate back to the Packer host's HTTP server.
+
     ```hcl
     common_data_source = "disk"
     ```
+
 * Renames all certificates to `*.ctr.example` and `*.pb7.example`. Please add your own custom certificates to the directories per the README.md.
 * Adds the ability for Packer to be run from any directory by including the use of `$(path.cwd)/`.
 * Adds the `ansible` provisioner to Linux builds for base configuration using roles. More updates to follow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## [Unreleased](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/unreleased)
+## Unreleased
 
-> Release Date: Unreleased
+> Release Date: Unreleased. Available in `main`.
 
 🧹 **Chore**:
 
@@ -11,9 +11,13 @@
 * Updates Almalinux 8 .iso and checksum to 8.6 release.
 * Updates CentOS Stream 8 checksum to latest release.
 * Updates Windows Server 2022 .iso and checksum to April 2022 release.
-* Updates Windows Server 11 .iso and checksum to May 2022 release.
+* Updates Windows 11 .iso and checksum to May 2022 release.
 * Updates `required_plugins` for `packer-plugin-vsphere` to `>= v1.0.4`.
 * Updates `required_plugins` and `packer-plugin-windows-update` to `>= v0.14.1`.
+* Updates `required_versons` for `terraform` to `>= v1.2.0`.
+* Updates requirements to include Ubuntu 22.04 as a tested operating system. <sup>*</sup>
+
+    > <sup>*</sup> You may be required to update your `.ssh/sshd_config` or `/etc/ssh/sshd_config` to allow authentication with RSA keys if you are using Ubuntu 22.04.
 
 ## [v22.04](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v22.04)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 [![The Changelog](https://img.shields.io/badge/The%20Changelog-Read-blue?style=for-the-badge&logo=github)](CHANGELOG.md)
 
-[![Open in Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-Open-blue?style=for-the-badge&logo=visualstudiocode)](https://open.vscode.dev/vmware-samples/packer-examples-for-vsphere)
-
 ![VMware vSphere 7.0 Update 2+](https://img.shields.io/badge/VMware%20vSphere-7.0%20Update%202+-blue?style=for-the-badge)
 
-![Packer 1.8.0+](https://img.shields.io/badge/HashiCorp%20Packer-1.8.0+-blue?style=for-the-badge&logo=packer)
+![Packer 1.8.0+](https://img.shields.io/badge/HashiCorp%20Packer-1.8.0+-blue?style=for-the-badge)
 
-![Ansible 2.9+](https://img.shields.io/badge/Ansible-2.9+-blue?style=for-the-badge&logo=ansible)
+![Ansible 2.9+](https://img.shields.io/badge/Ansible-2.9+-blue?style=for-the-badge)
 
 ## Table of Contents
 
@@ -74,13 +72,21 @@ The following builds are available:
 
 * HashiCorp [Packer][packer-install] 1.8.0 or higher.
   * Ubuntu:
-    * `sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl`
-    * `curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -`
-    * `sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"`
-    * `sudo apt-get update && sudo apt-get install terraform`
+    ```shell
+    sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
+
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+
+    sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+
+    sudo apt-get update && sudo apt-get install terraform
+    ```
   * macOS:
-    * `brew tap hashicorp/tap`
-    * `brew install hashicorp/tap/packer`
+    ```shell
+    brew tap hashicorp/tap
+
+    brew install hashicorp/tap/packer
+    ```
 * HashiCorp [Packer Plugin for VMware vSphere][packer-plugin-vsphere] (`vsphere-iso`) 1.0.3 or higher.
 * [Packer Plugin for Windows Updates][packer-plugin-windows-update] 0.14.1 or higher - a community plugin for HashiCorp Packer.
 
@@ -88,34 +94,96 @@ The following builds are available:
 
 **Additional Software Packages**:
 
-The following software packages must be installed on the Packer host:
+The following software packages must be installed on the opearing system running Packer:
 
 * [Git][download-git] command-line tools.
-  * Ubuntu: `apt-get install git`
-  * macOS: `brew install git`
+  * Ubuntu:
+
+    ```shell
+    apt-get install git
+    ```
+
+  * macOS:
+  
+    ```shell
+    brew install git
+    ```
+
 * [Ansible][ansible-docs] 2.9 or higher.
-  * Ubuntu: `apt-get install ansible`
-  * macOS: `brew install ansible`
+  * Ubuntu:
+  
+    ```shell
+    apt-get install ansible
+    ```
+
+  * macOS:
+  
+    ```shell
+    brew install ansible
+    ```
+
 * A command-line .iso creator. Packer will use one of the following:
-  * **xorriso** on Ubuntu: `apt-get install xorriso`
-  * **mkisofs** on Ubuntu: `apt-get install mkisofs`
+  * **xorriso** on Ubuntu:
+  
+    ```shell
+    apt-get install xorriso
+    ```
+
+  * **mkisofs** on Ubuntu:
+
+    ```shell
+    apt-get install mkisofs
+    ```
+
   * **hdiutil** on macOS: native
+
 * mkpasswd
-  * Ubuntu: `apt-get install whois`
-  * macOS: `brew install --cask docker`
+  * Ubuntu:
+
+    ```shell
+    apt-get install whois
+    ```
+
+  * macOS:
+
+    ```shell
+    brew install --cask docker
+    ```
+
 * Coreutils
-  * macOS: `brew install coreutils`
+  * macOS:
+
+    ```shell
+    brew install coreutils
+    ```
+
 * HashiCorp [Terraform][terraform-install] 1.2.0 or higher.
   * Ubuntu:
-    * `sudo apt-get update && sudo apt-get install terraform`
+
+    ```shell
+    sudo apt-get update && sudo apt-get install terraform
+    ```
+
   * macOS:
-    * `brew install hashicorp/tap/terraform`
+
+    ```shell
+    brew install hashicorp/tap/terraform
+    ```
+
 * [Gomplate](gomplate-install) 3.10.0 or higher.
   * Ubuntu:
-    * `sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/3.10.0/gomplate_linux-amd64`
-    * `sudo chmod 755 /usr/local/bin/gomplate`
+
+    ```shell
+    sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/3.10.0/gomplate_linux-amd64
+
+    sudo chmod 755 /usr/local/bin/gomplate
+    ```
+
   * macOS:
-    * `brew install gomplate`
+
+    ```shell
+    brew install gomplate
+    ```
 
 **Platform**:
 
@@ -509,7 +577,7 @@ The `cd_content` option is used when selecting `disk` unless the distribution do
 common_data_source = "disk"
 ```
 
-##### HTTP Binding
+##### HTTP Binding (Optional)
 
 If you need to define a specific IPv4 address from your host for Packer's HTTP Server, modify the `common_http_ip` variable from `null` to a `string` value that matches an IP address on your Packer host. For example:
 
@@ -569,9 +637,9 @@ vsphere_network              = "sfo-w01-seg-dhcp"
 vsphere_folder               = "sfo-w01-fd-templates"
 ```
 
-#### **Using Environment Variables**
+#### Using Environment Variables
 
-Alternatively, you can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files. You can add these to environmental variables using the included `set-envvars.sh` script:
+If you prefer not to save sensitive potentially information in cleartext files, you add the variables to environmental variables using the included `set-envvars.sh` script:
 
 ```console
 rainpole@macos> . ./set-envvars.sh
@@ -579,7 +647,7 @@ rainpole@macos> . ./set-envvars.sh
 
 > **NOTE**: You need to run the script as source or the shorthand "`.`".
 
-#### **Machine Image Variables**
+#### Machine Image Variables (Optional)
 
 Edit the `*.auto.pkvars.hcl` file in each `builds/<type>/<build>` folder to configure the following virtual machine hardware settings, as required:
 
@@ -604,11 +672,11 @@ Username and password variables are passed into the kickstart or cloud-init file
 
 #### Microsoft Windows Unattended amd Scripts
 
-Variables are passed into the [Microsoft Windows][microsoft-windows-unattend] unattend files (`autounattend.xml`) as Packer template files (`autounattend.pkrtpl.hcl`) to generate these on-demand. A PowerShell script is then used to configure the Linux machine image builds.
+Variables are passed into the [Microsoft Windows][microsoft-windows-unattend] unattend files (`autounattend.xml`) as Packer template files (`autounattend.pkrtpl.hcl`) to generate these on-demand. By default, each unattended file is set to use the [KMS client setup keys][microsoft-kms] as the **Product Key**.
 
-By default, each unattended file is set to use the [KMS client setup keys][microsoft-kms] as the **Product Key**.
+PowerShell scripts are used to configure the Windows machine image builds.
 
-**Need help customizing the configuration files?**
+Need help customizing the configuration files?
 
 * **VMware Photon OS** - Read the [Photon OS Kickstart Documentation][photon-kickstart].
 * **Ubuntu Server** - Install and run system-config-kickstart on a Ubuntu desktop.
@@ -630,6 +698,7 @@ Save a copy of your PEM encoded Root Certificate Authority certificate to the fo
 * `/certificates` for Windows machine images.
 
 These files are copied to the guest operating systems and added the certificate to the Trusted Certificate Authority of the guest operating system.
+
 Linux distributions uses the Ansible provisioner, but Windows still uses the shell provisioner at this time.
 
 ## Build
@@ -661,8 +730,9 @@ rainpole@macos> packer build -force \
 
 ### Build with Environmental Variables
 
-You can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files.
-You can add these to environmental variables using the included `set-envvars.sh` script:
+You can set your environment variables if you would prefer not to save sensitive information in cleartext files.
+
+You can add these to environmental variables using the included `set-envvars.sh` script.
 
 ```console
 rainpole@macos> . ./set-envvars.sh

--- a/README.md
+++ b/README.md
@@ -629,7 +629,8 @@ Save a copy of your PEM encoded Root Certificate Authority certificate to the fo
 * `/ansible/roles/base/files` for Linux machine images.
 * `/certificates` for Windows machine images.
 
-These files are copied to the guest operating systems and added the certificate to the Trusted Certificate Authority of the guest operating system. Linux distributions uses the Ansible provisioner, but Windows still uses the shell provisioner at this time.
+These files are copied to the guest operating systems and added the certificate to the Trusted Certificate Authority of the guest operating system.
+Linux distributions uses the Ansible provisioner, but Windows still uses the shell provisioner at this time.
 
 ## Build
 
@@ -660,7 +661,8 @@ rainpole@macos> packer build -force \
 
 ### Build with Environmental Variables
 
-You can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files. You can add these to environmental variables using the included `set-envvars.sh` script:
+You can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files.
+You can add these to environmental variables using the included `set-envvars.sh` script:
 
 ```console
 rainpole@macos> . ./set-envvars.sh

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # HashiCorp Packer and VMware vSphere to Build Private Cloud Machine Images
 
-<img alt="Last Commit" src="https://img.shields.io/github/last-commit/vmware-samples/packer-examples-for-vsphere?style=for-the-badge&logo=github"> [<img alt="The Changelog" src="https://img.shields.io/badge/The%20Changelog-Read-blue?style=for-the-badge&logo=github">](CHANGELOG.md) [<img alt="Open in Visual Studio Code" src="https://img.shields.io/badge/Visual%20Studio%20Code-Open-blue?style=for-the-badge&logo=visualstudiocode">](https://open.vscode.dev/vmware-samples/packer-examples-for-vsphere)
-<br/>
-<img alt="VMware vSphere 7.0 Update 2+" src="https://img.shields.io/badge/VMware%20vSphere-7.0%20Update%202+-blue?style=for-the-badge">
-<img alt="Packer 1.8.0+" src="https://img.shields.io/badge/HashiCorp%20Packer-1.8.0+-blue?style=for-the-badge&logo=packer">
-<img alt="Ansible 2.9+" src="https://img.shields.io/badge/Ansible-2.9+-blue?style=for-the-badge&logo=ansible">
+![Last Commit](https://img.shields.io/github/last-commit/vmware-samples/packer-examples-for-vsphere?style=for-the-badge&logo=github)
+
+[![The Changelog](https://img.shields.io/badge/The%20Changelog-Read-blue?style=for-the-badge&logo=github)](CHANGELOG.md)
+
+[![Open in Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-Open-blue?style=for-the-badge&logo=visualstudiocode)](https://open.vscode.dev/vmware-samples/packer-examples-for-vsphere)
+
+![VMware vSphere 7.0 Update 2+](https://img.shields.io/badge/VMware%20vSphere-7.0%20Update%202+-blue?style=for-the-badge)
+
+![Packer 1.8.0+](https://img.shields.io/badge/HashiCorp%20Packer-1.8.0+-blue?style=for-the-badge&logo=packer)
+
+![Ansible 2.9+](https://img.shields.io/badge/Ansible-2.9+-blue?style=for-the-badge&logo=ansible)
 
 ## Table of Contents
+
 1. [Introduction](#Introduction)
-2. [Requirements](#Requirements)
-3. [Configuration](#Configuration)
-4. [Build](#Build)
-5. [Troubleshoot](#Troubleshoot)
-6. [Credits](#Credits)
+1. [Requirements](#Requirements)
+1. [Configuration](#Configuration)
+1. [Build](#Build)
+1. [Troubleshoot](#Troubleshoot)
+1. [Credits](#Credits)
 
 ## Introduction
 
@@ -24,7 +31,8 @@ By default, the machine image artifacts are transferred to a [vSphere Content Li
 
 The following builds are available:
 
-**Linux Distributions**
+### Linux Distributions
+
 * VMware Photon OS 4
 * Ubuntu Server 22.04 LTS
 * Ubuntu Server 20.04 LTS
@@ -37,7 +45,8 @@ The following builds are available:
 * CentOS Linux 8
 * CentOS Linux 7
 
-**Microsoft Windows** - _Core and Desktop Experience_
+### Microsoft Windows - _Core and Desktop Experience_
+
 * Microsoft Windows Server 2022 - Standard and Datacenter
 * Microsoft Windows Server 2019 - Standard and Datacenter
 * Microsoft Windows Server 2016 - Standard and Datacenter
@@ -45,6 +54,7 @@ The following builds are available:
 * Microsoft Windows 10
 
 > **NOTES**:
+>
 > * Guest customization is not currently supported for AlmaLinux OS and Rocky Linux in vCenter Server 7.0 Update 2.
 >
 > * The Microsoft Windows 11 machine image uses a virtual trusted platform module (vTPM). Refer to the VMware vSphere [product documenation][vsphere-tpm] for requirements and pre-requisites.
@@ -53,55 +63,62 @@ The following builds are available:
 
 ## Requirements
 
-**Packer**:
-* HashiCorp [Packer][packer-install] 1.8.0 or higher.
-* HashiCorp [Packer Plugin for VMware vSphere][packer-plugin-vsphere] (`vsphere-iso`) 1.0.3 or higher.
-* [Packer Plugin for Windows Updates][packer-plugin-windows-update] 0.14.0 or higher - a community plugin for HashiCorp Packer.
-
-    > Required plugins are automatically downloaded and initialized when using `./build.sh`. For dark sites, you may download the plugins and place these same directory as your Packer executable `/usr/local/bin` or `$HOME/.packer.d/plugins`.
-
 **Operating Systems**:
-* Ubuntu Server 20.04 LTS
-* macOS Big Sur and Monterey (Intel)
+
+* Ubuntu Server 22.04 LTS and 20.04 LTS
+* macOS Monterey and Big Sur (Intel)
 
     > Operating systems and versions tested with the project.
+
+**Packer**:
+
+* HashiCorp [Packer][packer-install] 1.8.0 or higher.
+  * Ubuntu:
+    * `sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl`
+    * `curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -`
+    * `sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"`
+    * `sudo apt-get update && sudo apt-get install terraform`
+  * macOS:
+    * `brew tap hashicorp/tap`
+    * `brew install hashicorp/tap/packer`
+* HashiCorp [Packer Plugin for VMware vSphere][packer-plugin-vsphere] (`vsphere-iso`) 1.0.3 or higher.
+* [Packer Plugin for Windows Updates][packer-plugin-windows-update] 0.14.1 or higher - a community plugin for HashiCorp Packer.
+
+    > Required plugins are automatically downloaded and initialized when using `./build.sh`. For dark sites, you may download the plugins and place these same directory as your Packer executable `/usr/local/bin` or `$HOME/.packer.d/plugins`.
 
 **Additional Software Packages**:
 
 The following software packages must be installed on the Packer host:
 
 * [Git][download-git] command-line tools.
-  - Ubuntu: `apt-get install git`
-  - macOS: `brew install git`
+  * Ubuntu: `apt-get install git`
+  * macOS: `brew install git`
 * [Ansible][ansible-docs] 2.9 or higher.
-  - Ubuntu: `apt-get install ansible`
-  - macOS: `brew install ansible`
+  * Ubuntu: `apt-get install ansible`
+  * macOS: `brew install ansible`
 * A command-line .iso creator. Packer will use one of the following:
-  - **xorriso** on Ubuntu: `apt-get install xorriso`
-  - **mkisofs** on Ubuntu: `apt-get install mkisofs`
-  - **hdiutil** on macOS: native
+  * **xorriso** on Ubuntu: `apt-get install xorriso`
+  * **mkisofs** on Ubuntu: `apt-get install mkisofs`
+  * **hdiutil** on macOS: native
 * mkpasswd
-  - Ubuntu: `apt-get install whois`
-  - macOS: `brew install --cask docker`
+  * Ubuntu: `apt-get install whois`
+  * macOS: `brew install --cask docker`
 * Coreutils
-  - macOS: `brew install coreutils`
-* HashiCorp [Terraform][terraform-install] 1.1.7 or higher.
-  - Ubuntu:
-    - `sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl`
-    - `curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -`
-    - `sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"`
-    - `sudo apt-get update && sudo apt-get install terraform`
-  - macOS:
-    - `brew tap hashicorp/tap`
-    - `brew install hashicorp/tap/terraform`
+  * macOS: `brew install coreutils`
+* HashiCorp [Terraform][terraform-install] 1.2.0 or higher.
+  * Ubuntu:
+    * `sudo apt-get update && sudo apt-get install terraform`
+  * macOS:
+    * `brew install hashicorp/tap/terraform`
 * [Gomplate](gomplate-install) 3.10.0 or higher.
-  - Ubuntu:
-    - `sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/<version>/gomplate_<os>-<arch>`
-    - `sudo chmod 755 /usr/local/bin/gomplate`
-  - macOS:
-    - `brew install gomplate`
+  * Ubuntu:
+    * `sudo curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/3.10.0/gomplate_linux-amd64`
+    * `sudo chmod 755 /usr/local/bin/gomplate`
+  * macOS:
+    * `brew install gomplate`
 
 **Platform**:
+
 * VMware Cloud Foundation 4.2 or higher, or
 * VMware vSphere 7.0 Update 2 or higher
 
@@ -179,6 +196,7 @@ The directory structure of the repository.
 ```
 
 The files are distributed in the following directories.
+
 * **`ansible`** - contains the Ansible roles to prepare a Linux machine image build.
 * **`builds`** - contains the templates, variables, and configuration files for the machine image build.
 * **`scripts`** - contains the scripts to initialize and prepare a Windows machine image build.
@@ -186,48 +204,48 @@ The files are distributed in the following directories.
 * **`manifests`** - manifests created after the completion of the machine image build.
 * **`terraform`** - contains example Terraform plans to test machine image builds.
 
-> ⚠️ **WARNING**:
->
-> When forking the project for upstream contribution, please be mindful not to make changes that may expose your sensitive information, such as passwords, keys, certificates, etc.
+> ⚠️ **WARNING**: When forking the project for upstream contribution, please be mindful not to make changes that may expose your sensitive information, such as passwords, keys, certificates, etc.
 
 ### Step 2 - Download the Guest Operating Systems ISOs
 
 1. Download the x64 guest operating system [.iso][iso] images.
 
-    **Linux Distributions**
-    * VMware Photon OS 4 Server
-        * [Download][download-linux-photon-server-4] the 4.0 Rev2 release of the **FULL** `.iso` image. (_e.g._ `photon-4.0-xxxxxxxxx.iso`)
-    * Ubuntu Server 22.04 LTS
-        * [Download][download-linux-ubuntu-server-22-04-lts] the latest **LIVE** release `.iso` image. (_e.g._ `ubuntu-22.04.x-live-server-amd64.iso`)
-    * Ubuntu Server 20.04 LTS
-        * [Download][download-linux-ubuntu-server-20-04-lts] the latest **LIVE** release `.iso` image. (_e.g._ `ubuntu-20.04.x-live-server-amd64.iso`)
-    * Ubuntu Server 18.04 LTS
-        * [Download][download-linux-ubuntu-server-18-04-lts] the latest legacy **NON-LIVE** release `.iso` image. (_e.g._ `ubuntu-18.04.x-server-amd64.iso`)
-    * Red Hat Enterprise Linux 8 Server
-        * [Download][download-linux-redhat-server-8] the latest release of the **FULL** `.iso` image. (_e.g._ `rhel-8.x-x86_64-dvd1.iso`)
-    * Red Hat Enterprise Linux 7 Server
-        * [Download][download-linux-redhat-server-7] the latest release of the **FULL** `.iso` image. (_e.g._ `rhel-server-7.x-x86_64-dvd1.iso`)
-    * AlmaLinux OS 8
-        * [Download][download-linux-almalinux-server-8] the latest release of the **FULL** `.iso` image. (_e.g._ `AlmaLinux-8.x-x86_64-dvd1.iso`)
-    * Rocky Linux 8
-        * [Download][download-linux-rocky-server-8] the latest release of the **FULL** `.iso` image. (_e.g._ `Rocky-8.x-x86_64-dvd1.iso`)
-    * CentOS Stream 8
-        * [Download][download-linux-centos-stream-8] the latest release of the **FULL** `.iso` image. (_e.g._ `CentOS-Stream-8-x86_64-latest-dvd1.iso`)
-    * CentOS Linux 8
-        * [Download][download-linux-centos-server-8] the latest release of the **FULL** `.iso` image. (_e.g._ `CentOS-8.x.xxxx-x86_64-dvd1.iso`)
-    * CentOS Linux 7
-        * [Download][download-linux-centos-server-7] the latest release of the **FULL** `.iso` image. (_e.g._ `CentOS-7-x86_64-DVD.iso`)
+    Linux Distributions:
 
-    **Microsoft Windows**
+    * VMware Photon OS 4 Server
+        * [Download][download-linux-photon-server-4] the 4.0 Rev2 release of the **FULL** `.iso` image. (_e.g.,_ `photon-4.0-xxxxxxxxx.iso`)
+    * Ubuntu Server 22.04 LTS
+        * [Download][download-linux-ubuntu-server-22-04-lts] the latest **LIVE** release `.iso` image. (_e.g.,_ `ubuntu-22.04.x-live-server-amd64.iso`)
+    * Ubuntu Server 20.04 LTS
+        * [Download][download-linux-ubuntu-server-20-04-lts] the latest **LIVE** release `.iso` image. (_e.g.,_ `ubuntu-20.04.x-live-server-amd64.iso`)
+    * Ubuntu Server 18.04 LTS
+        * [Download][download-linux-ubuntu-server-18-04-lts] the latest legacy **NON-LIVE** release `.iso` image. (_e.g.,_ `ubuntu-18.04.x-server-amd64.iso`)
+    * Red Hat Enterprise Linux 8 Server
+        * [Download][download-linux-redhat-server-8] the latest release of the **FULL** `.iso` image. (_e.g.,_ `rhel-8.x-x86_64-dvd1.iso`)
+    * Red Hat Enterprise Linux 7 Server
+        * [Download][download-linux-redhat-server-7] the latest release of the **FULL** `.iso` image. (_e.g.,_ `rhel-server-7.x-x86_64-dvd1.iso`)
+    * AlmaLinux OS 8
+        * [Download][download-linux-almalinux-server-8] the latest release of the **FULL** `.iso` image. (_e.g.,_ `AlmaLinux-8.x-x86_64-dvd1.iso`)
+    * Rocky Linux 8
+        * [Download][download-linux-rocky-server-8] the latest release of the **FULL** `.iso` image. (_e.g.,_ `Rocky-8.x-x86_64-dvd1.iso`)
+    * CentOS Stream 8
+        * [Download][download-linux-centos-stream-8] the latest release of the **FULL** `.iso` image. (_e.g.,_ `CentOS-Stream-8-x86_64-latest-dvd1.iso`)
+    * CentOS Linux 8
+        * [Download][download-linux-centos-server-8] the latest release of the **FULL** `.iso` image. (_e.g.,_ `CentOS-8.x.xxxx-x86_64-dvd1.iso`)
+    * CentOS Linux 7
+        * [Download][download-linux-centos-server-7] the latest release of the **FULL** `.iso` image. (_e.g.,_ `CentOS-7-x86_64-DVD.iso`)
+
+    Microsoft Windows:
+
     * Microsoft Windows Server 2022
     * Microsoft Windows Server 2019
     * Microsoft Windows Server 2016
     * Microsoft Windows 11
     * Microsoft Windows 10
 
-3. Obtain the checksum type (_e.g._ `sha256`, `md5`, etc.) and checksum value for each guest operating system `.iso` image from the vendor. This will be use in the build input variables.
+1. Obtain the checksum type (_e.g.,_ `sha256`, `md5`, etc.) and checksum value for each guest operating system `.iso` image from the vendor. This will be use in the build input variables.
 
-4. [Upload][vsphere-upload] your guest operating system `.iso` images to the ISO datastore and paths that will be used in your variables.
+1. [Upload][vsphere-upload] your guest operating system `.iso` images to the ISO datastore and paths that will be used in your variables.
 
     **Example**: `config/common.pkvars.hcl`
 
@@ -288,44 +306,46 @@ If you would like to automate the creation of the custom vSphere role, a Terrafo
 cd terraform/vsphere-role
 ```
 
-2. Duplicate the `terraform.tfvars.example` file to `terraform.tfvars` in the directory.
+1. Duplicate the `terraform.tfvars.example` file to `terraform.tfvars` in the directory.
 
 ```console
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-3. Open the `terraform.tfvars` file and update the variables according to your environment.
+1. Open the `terraform.tfvars` file and update the variables according to your environment.
 
-4. Initialize the current directory and the required Terraform provider for VMware vSphere.
+1. Initialize the current directory and the required Terraform provider for VMware vSphere.
 
-```console
-terraform init
-```
+    ```console
+    terraform init
+    ```
 
-5. Create a Terraform plan and save the output to a file.
+1. Create a Terraform plan and save the output to a file.
 
-```console
-terraform plan -out=tfplan
-```
+    ```console
+    terraform plan -out=tfplan
+    ```
 
-6. Apply the Terraform plan.
+1. Apply the Terraform plan.
 
-```console
-terraform apply tfplan
-```
+    ```console
+    terraform apply tfplan
+    ```
 
 Once the custom vSphere role is created, assign **Global Permissions** in vSphere for the service account used for the HashiCorp Packer to VMware vSphere integration. Global permissions are required for the content library. For example:
 
 1. Log in to the vCenter Server at _<management_vcenter_server_fqdn>/ui_ as `administrator@vsphere.local`.
-2. Select **Menu** > **Administration**.
-3. In the left pane, select **Access control** > **Global permissions** and click the **Add permissions** icon.
-4. In the **Add permissions** dialog box, enter the service account (_e.g._ svc-packer-vsphere@rainpole.io), select the custom role (_e.g._ Packer to vSphere Integration Role) and the **Propagate to children** check box, and click OK.
+1. Select **Menu** > **Administration**.
+1. In the left pane, select **Access control** > **Global permissions** and click the **Add permissions** icon.
+1. In the **Add permissions** dialog box, enter the service account (_e.g.,_ svc-packer-vsphere@rainpole.io), select the custom role (_e.g.,_ Packer to vSphere Integration Role) and the **Propagate to children** check box, and click OK.
 
 In an environment with many vCenter Server instances, such as management and workload domains, you may wish to further reduce the scope of access across the infrastructure in vSphere for the service account. For example, if you do not want Packer to have access to your management domain, but only allow access to workload domains:
 
 1. From the **Hosts and clusters** inventory, select management domain vCenter Server to restrict scope, and click the **Permissions** tab.
-2. Select the service account with the custom role assigned and click the **Change role** icon.
-3. In the **Change role** dialog box, from the **Role** drop-down menu, select **No Access**, select the **Propagate to children** check box, and click **OK**.
+
+1. Select the service account with the custom role assigned and click the **Change role** icon.
+
+1. In the **Change role** dialog box, from the **Role** drop-down menu, select **No Access**, select the **Propagate to children** check box, and click **OK**.
 
 ### Step 4 - Configure the Variables
 
@@ -341,6 +361,7 @@ The `config` folder is the default folder, You may override the default by passi
 ./config.sh foo
 ./build.sh foo
 ```
+
 For example, this is useful for the purposes of running machine image builds for different environment.
 
 **San Francisco:** us-west-1
@@ -371,6 +392,7 @@ build_password           = "<plaintext_password>"
 build_password_encrypted = "<sha512_encrypted_password>"
 build_key                = "<public_key>"
 ```
+
 You can also override the `build_key` value with contents of a file, if required.
 
 For example:
@@ -396,6 +418,7 @@ rainpole@linux>  mkpasswd -m sha-512
 Password: ***************
 [password hash]
 ```
+
 Generate a public key for the `build_key` for public key authentication.
 
 **Example**: macOS and Linux.
@@ -428,6 +451,7 @@ Edit the `config/ansible.pkvars.hcl` file to configure the following:
 ansible_username = "ansible"
 ansible_key      = "<public_key>"
 ```
+
 >**NOTE**: A random password is generated for the Ansible user.
 
 You can also override the `ansible_key` value with contents of a file, if required.
@@ -508,6 +532,7 @@ communicator_proxy_port     = 1080
 communicator_proxy_username = "rainpole"
 communicator_proxy_password = "<plaintext_password>"
 ```
+
 ##### Red Hat Subscription Manager Variables
 
 Edit the `config/redhat.pkvars.hcl` file to configure the following:
@@ -543,6 +568,7 @@ vsphere_datastore            = "sfo-w01-cl01-ds-vsan01"
 vsphere_network              = "sfo-w01-seg-dhcp"
 vsphere_folder               = "sfo-w01-fd-templates"
 ```
+
 #### **Using Environment Variables**
 
 Alternatively, you can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files. You can add these to environmental variables using the included `set-envvars.sh` script:
@@ -568,7 +594,6 @@ Edit the `*.auto.pkvars.hcl` file in each `builds/<type>/<build>` folder to conf
 
     >**Note**: All `variables.auto.pkvars.hcl` default to using the [VMware Paravirtual SCSI controller][vmware-pvscsi] and the [VMXNET 3][vmware-vmxnet3] network card device types.
 
-
 ### Step 5 - Modify the Configurations (Optional)
 
 If required, modify the configuration files for the Linux distributions and Microsoft Windows.
@@ -593,14 +618,16 @@ By default, each unattended file is set to use the [KMS client setup keys][micro
     ssh -X rainpole@ubuntu-desktop
     sudo system-config-kickstart
     ```
+
 * **Red Hat Enterprise Linux** (_as well as CentOS Linux/Stream, AlmaLinux OS, and Rocky Linux_) - Use the [Red Hat Kickstart Generator][redhat-kickstart].
 * **Microsoft Windows** - Use the Microsoft Windows [Answer File Generator][microsoft-windows-afg] if you need to customize the provided examples further.
 
 ### Step 6 - Add Certificates
 
 Save a copy of your PEM encoded Root Certificate Authority certificate to the following in `.cer` format.
-- `/ansible/roles/base/files` for Linux machine images.
-- `/certificates` for Windows machine images.
+
+* `/ansible/roles/base/files` for Linux machine images.
+* `/certificates` for Windows machine images.
 
 These files are copied to the guest operating systems and added the certificate to the Trusted Certificate Authority of the guest operating system. Linux distributions uses the Ansible provisioner, but Windows still uses the shell provisioner at this time.
 
@@ -633,6 +660,14 @@ rainpole@macos> packer build -force \
 
 ### Build with Environmental Variables
 
+You can set your environment variables if you would prefer not to save sensitive potentially information in cleartext files. You can add these to environmental variables using the included `set-envvars.sh` script:
+
+```console
+rainpole@macos> . ./set-envvars.sh
+```
+
+> **NOTE**: You need to run the script as source or the shorthand "`.`".
+
 Initialize the plugins:
 
 ```console
@@ -664,6 +699,7 @@ Happy building!!!
 * Read [Debugging Packer Builds][packer-debug].
 
 ## Credits
+
 * Owen Reynolds [@OVDamn][credits-owen-reynolds-twitter]
 
     [VMware Tools for Windows][credits-owen-reynolds-github] installation PowerShell script.

--- a/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
@@ -29,9 +29,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/almalinux"
-iso_file           = "AlmaLinux-8.5-x86_64-dvd.iso"
+iso_file           = "AlmaLinux-8.6-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "54b8881bebd924e4699ed12634187a82156fdb0fa57ec24058d04d70d2f033b3"
+iso_checksum_value = "8c3bd1ff3d88b5599147626fa2616d85edcc861ec00edd6863b81dbfb135874c"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -31,7 +31,7 @@ vm_network_card          = "vmxnet3"
 iso_path           = "iso/linux/centos"
 iso_file           = "CentOS-Stream-8-x86_64-latest-dvd1.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "b8bf31e7a488ad00abdb4674256e40976dcf0558d34fda425284a1a7ad8c2cfc"
+iso_checksum_value = "9675a47b19054090dd49431a66d3f7b6fc15a755c4af0b56e6b0c32221870a14"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/centos/8/linux-centos.pkr.hcl
+++ b/builds/linux/centos/8/linux-centos.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/photon/4/linux-photon.pkr.hcl
+++ b/builds/linux/photon/4/linux-photon.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
@@ -29,9 +29,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/rhel"
-iso_file           = "rhel-8.5-x86_64-dvd.iso"
+iso_file           = "rhel-8.6-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "1f78e705cd1d8897a05afa060f77d81ed81ac141c2465d4763c0382aa96cadd0"
+iso_checksum_value = "c324f3b07283f9393168f0a4ad2167ebbf7e4699d65c9670e0d9e58ba4e2a9a8"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
+++ b/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
@@ -29,9 +29,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/rocky"
-iso_file           = "Rocky-8.5-x86_64-dvd1.iso"
+iso_file           = "Rocky-8.6-x86_64-dvd1.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "0081f8b969d0cef426530f6d618b962c7a01e71eb12a40581a83241f22dfdc25"
+iso_checksum_value = "1d48e0af63d07ff4e582a1819348e714c694e7fd33207f48879c2bc806960786"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -10,7 +10,7 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -10,13 +10,13 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }
   required_plugins {
     windows-update = {
-      version = ">= 0.14.0"
+      version = ">= 0.14.1"
       source  = "github.com/rgl/windows-update"
     }
   }

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -37,9 +37,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_11_business_editions_updated_jan_2022_x64_dvd_6e14eeb6.iso"
+iso_file           = "en-us_windows_11_business_editions_updated_may_2022_x64_dvd_f6700d97.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "9999CBFC54C41FB9B861EF2C4602948893C87357ADA4CBC5DC2A060A60DC6403"
+iso_checksum_value = "A138016401223BBE927A7930B0C70948FDBF0B2B1DEE216E6D559061493F2EC6"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -10,13 +10,13 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }
   required_plugins {
     windows-update = {
-      version = ">= 0.14.0"
+      version = ">= 0.14.1"
       source  = "github.com/rgl/windows-update"
     }
   }

--- a/builds/windows/server/2016/windows-server.pkr.hcl
+++ b/builds/windows/server/2016/windows-server.pkr.hcl
@@ -10,13 +10,13 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }
   required_plugins {
     windows-update = {
-      version = ">= 0.14.0"
+      version = ">= 0.14.1"
       source  = "github.com/rgl/windows-update"
     }
   }

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -10,13 +10,13 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }
   required_plugins {
     windows-update = {
-      version = ">= 0.14.0"
+      version = ">= 0.14.1"
       source  = "github.com/rgl/windows-update"
     }
   }

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -43,9 +43,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/windows/server"
-iso_file           = "en-us_windows_server_2022_updated_feb_2022_x64_dvd_d4a089c1.iso"
+iso_file           = "en-us_windows_server_2022_updated_april_2022_x64_dvd_d428acee.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "5140AC5FB8F48EFDF4BFCF1E7BE14030F9164A824F12A9D08A45CDC72DAC8D15"
+iso_checksum_value = "1E5C4A4EA7BB51DAAC00D16D070992EC6F863BA5691401CC52CACC1DE6BF5FDC"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -10,13 +10,13 @@ packer {
   required_version = ">= 1.8.0"
   required_plugins {
     vsphere = {
-      version = ">= v1.0.3"
+      version = ">= v1.0.4"
       source  = "github.com/hashicorp/vsphere"
     }
   }
   required_plugins {
     windows-update = {
-      version = ">= 0.14.0"
+      version = ">= 0.14.1"
       source  = "github.com/rgl/windows-update"
     }
   }

--- a/terraform/vsphere-role/versions.tf
+++ b/terraform/vsphere-role/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/template-linux-cloud-init/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-cloud-init/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/template-linux-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-guest-customization/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }

--- a/terraform/vsphere-virtual-machine/template-windows-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-windows-guest-customization/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.1.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.0"
 }


### PR DESCRIPTION
## Summary of Pull Request

* Updates Red Hat Enterprise Linux 8 .iso and checksum to 8.6 release.
* Updates Rocky Linux 8 .iso and checksum to 8.6 release.
* Updates Almalinux 8 .iso and checksum to 8.6 release.
* Updates CentOS Stream 8 checksum to latest release.
* Updates Windows Server 2022 .iso and checksum to April 2022 release.
* Updates Windows Server 11 .iso and checksum to May 2022 release.
* Updates `required_plugins` for `packer-plugin-vsphere` to `>= v1.0.4`.
* Updates `required_plugins` and `packer-plugin-windows-update` to `>= v0.14.1`.
* Updates `required_versons` for `terraform` to `>= v1.2.0`.

## Type of Pull Request

- [ ] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [X] This is something else.
      Please describe: Chore (+ Docs)

## Related to Existing Issues

Closes #204 

## Test and Documentation Coverage

- [X] Tests have been completed (for bugfixes / features).
- [X] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
