### PR TITLE
feat: Add option for `video_ram` and `displays`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 * Updates `required_plugins` for `packer-plugin-vsphere` to `>= v1.0.6`.
 
+💫  **Enhancement**:
+
+* Adds options for setting the number of video displays and the size for the video memory for both Windows 11 and 10, which is useful for virtual desktop use cases (_e.g._, Horizon). The ability to set the number of displays was added in  `v1.0.6` of `packer-plugin-vsphere`.
 
 ## [v22.06](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v22.06)
 

--- a/builds/windows/desktop/10/variables.pkr.hcl
+++ b/builds/windows/desktop/10/variables.pkr.hcl
@@ -189,6 +189,18 @@ variable "vm_network_card" {
   default     = "vmxnet3"
 }
 
+variable "vm_video_mem_size" {
+  type        = number
+  description = "The size for the video memory in KB. (e.g. 4096)"
+  default     = 4096
+}
+
+variable "vm_video_displays" {
+  type        = number
+  description = "The number of video displays. (e.g. 1)"
+  default     = 1
+}
+
 variable "common_vm_version" {
   type        = number
   description = "The vSphere virtual hardware version. (e.g. '19')"

--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -33,6 +33,8 @@ vm_disk_size             = 102400
 vm_disk_controller_type  = ["pvscsi"]
 vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
+vm_video_mem_size        = 131072
+vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path           = "iso/windows/desktop"

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -59,6 +59,8 @@ source "vsphere-iso" "windows-desktop" {
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
   RAM_hot_plug         = var.vm_mem_hot_add
+  video_ram            = var.vm_video_mem_size
+  displays             = var.vm_video_displays
   cdrom_type           = var.vm_cdrom_type
   disk_controller_type = var.vm_disk_controller_type
   storage {
@@ -185,6 +187,8 @@ build {
       vm_guest_os_type         = var.vm_guest_os_type
       vm_mem_size              = var.vm_mem_size
       vm_network_card          = var.vm_network_card
+      vm_video_memory          = var.vm_video_mem_size
+      vm_video_displays        = var.vm_video_displays
       vsphere_cluster          = var.vsphere_cluster
       vsphere_datacenter       = var.vsphere_datacenter
       vsphere_datastore        = var.vsphere_datastore

--- a/builds/windows/desktop/11/variables.pkr.hcl
+++ b/builds/windows/desktop/11/variables.pkr.hcl
@@ -195,6 +195,18 @@ variable "vm_network_card" {
   default     = "vmxnet3"
 }
 
+variable "vm_video_mem_size" {
+  type        = number
+  description = "The size for the video memory in KB. (e.g. 4096)"
+  default     = 4096
+}
+
+variable "vm_video_displays" {
+  type        = number
+  description = "The number of video displays. (e.g. 1)"
+  default     = 1
+}
+
 variable "common_vm_version" {
   type        = number
   description = "The vSphere virtual hardware version. (e.g. '19')"

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -34,6 +34,8 @@ vm_disk_size             = 102400
 vm_disk_controller_type  = ["pvscsi"]
 vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
+vm_video_mem_size        = 131072
+vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path           = "iso/windows/desktop"

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -59,6 +59,8 @@ source "vsphere-iso" "windows-desktop" {
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
   RAM_hot_plug         = var.vm_mem_hot_add
+  video_ram            = var.vm_video_mem_size
+  displays             = var.vm_video_displays
   vTPM                 = var.vm_vtpm
   cdrom_type           = var.vm_cdrom_type
   disk_controller_type = var.vm_disk_controller_type
@@ -187,6 +189,8 @@ build {
       vm_guest_os_type         = var.vm_guest_os_type
       vm_mem_size              = var.vm_mem_size
       vm_network_card          = var.vm_network_card
+      vm_video_memory          = var.vm_video_mem_size
+      vm_video_displays        = var.vm_video_displays
       vm_vtpm                  = var.vm_vtpm
       vsphere_cluster          = var.vsphere_cluster
       vsphere_datacenter       = var.vsphere_datacenter


### PR DESCRIPTION
## Summary of Pull Request

Adds options for setting the number of video displays and the size for the video memory for both Windows 11 and 10. The ability to set the number of displays [was added](https://github.com/hashicorp/packer-plugin-vsphere/pull/201) in  `v1.0.6` of `packer-plugin-vsphere`.


```hcl
variable "vm_video_mem_size" {
  type        = number
  description = "The size for the video memory in KB. (e.g. 4096)"
  default     = 4096
}

variable "vm_video_displays" {
  type        = number
  description = "The number of video displays. (e.g. 1)"
  default     = 1
}
````

```hcl
source "vsphere-iso" "windows-desktop" {
  ... # other configurations
  video_ram            = var.vm_video_mem_size
  displays             = var.vm_video_displays
  ... # other configurations
}
```

```hcl
// Virtual Machine Hardware Settings
... # other configurations
vm_video_mem_size        = 131072
vm_video_displays        = 1
```

## Type of Pull Request

- [ ] This is a bugfix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

- [x] Tests have been completed (for bugfixes / features).
- [x] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
