### PR TITLE
fix: Set user context for Ansible provisioner

### DIFF
--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-almalinux"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-almalinux"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-centos"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-centos-stream"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-centos-stream"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/photon/4/linux-photon.pkr.hcl
+++ b/builds/linux/photon/4/linux-photon.pkr.hcl
@@ -132,6 +132,7 @@ build {
   sources = ["source.vsphere-iso.linux-photon"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -136,6 +136,7 @@ build {
   sources = ["source.vsphere-iso.linux-rhel"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -136,6 +136,7 @@ build {
   sources = ["source.vsphere-iso.linux-rhel"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/rhel/9/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/9/linux-rhel.pkr.hcl
@@ -136,6 +136,7 @@ build {
   sources = ["source.vsphere-iso.linux-rhel"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-rocky"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -134,6 +134,7 @@ build {
   sources = ["source.vsphere-iso.linux-rocky"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
@@ -141,6 +141,7 @@ build {
   sources = ["source.vsphere-iso.linux-ubuntu"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -138,6 +138,7 @@ build {
   sources = ["source.vsphere-iso.linux-ubuntu"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -138,6 +138,7 @@ build {
   sources = ["source.vsphere-iso.linux-ubuntu"]
 
   provisioner "ansible" {
+    user          = var.build_username
     playbook_file = "${path.cwd}/ansible/main.yml"
     roles_path    = "${path.cwd}/ansible/roles"
     ansible_env_vars = [


### PR DESCRIPTION
## Summary of Pull Request

Set the Ansible user to run under the context of the `var.build_username` on the image.

## Type of Pull Request

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes #216 

## Test and Documentation Coverage

- [x] Tests have been completed (for bugfixes / features).
- [ ] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
