### PR TITLE
feat: add support for `iso_url ` builder configuration

### DIFF
--- a/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/almalinux"
 iso_file           = "AlmaLinux-8.6-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-almalinux" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/almalinux/8/variables.pkr.hcl
+++ b/builds/linux/almalinux/8/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso'/linux/almalinux')"

--- a/builds/linux/almalinux/9/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/almalinux"
 iso_file           = "AlmaLinux-9.0-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-almalinux" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/almalinux/9/variables.pkr.hcl
+++ b/builds/linux/almalinux/9/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso'/linux/almalinux')"

--- a/builds/linux/centos/7/linux-centos.auto.pkrvars.hcl
+++ b/builds/linux/centos/7/linux-centos.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/centos"
 iso_file           = "CentOS-7-x86_64-DVD-2009.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-centos" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/centos/7/variables.pkr.hcl
+++ b/builds/linux/centos/7/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/centos')"

--- a/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/centos"
 iso_file           = "CentOS-Stream-8-x86_64-latest-dvd1.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-centos-stream" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/centos/8-stream/variables.pkr.hcl
+++ b/builds/linux/centos/8-stream/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/centos')"

--- a/builds/linux/centos/9-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/centos"
 iso_file           = "CentOS-Stream-9-latest-x86_64-dvd1.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-centos-stream" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/centos/9-stream/variables.pkr.hcl
+++ b/builds/linux/centos/9-stream/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/centos')"

--- a/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
+++ b/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = false
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/debian"
 iso_file           = "debian-11.4.0-amd64-netinst.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/debian/11/linux-debian.pkr.hcl
+++ b/builds/linux/debian/11/linux-debian.pkr.hcl
@@ -20,9 +20,9 @@ packer {
 //  Defines the local variables.
 
 locals {
-  build_by      = "Built by: HashiCorp Packer ${packer.version}"
-  build_date    = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  build_version = formatdate("YY.MM", timestamp())
+  build_by          = "Built by: HashiCorp Packer ${packer.version}"
+  build_date        = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
+  build_version     = formatdate("YY.MM", timestamp())
   build_description = "Version: v${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}"
   iso_paths         = ["[${var.common_iso_datastore}] ${var.iso_path}/${var.iso_file}"]
   iso_checksum      = "${var.iso_checksum_type}:${var.iso_checksum_value}"
@@ -85,8 +85,9 @@ source "vsphere-iso" "linux-debian" {
   notes                = local.build_description
 
   // Removable Media Settings
-  iso_paths    = local.iso_paths
-  iso_checksum = local.iso_checksum
+  iso_url        = var.iso_url
+  iso_paths      = local.iso_paths
+  iso_checksum   = local.iso_checksum
   http_content   = var.common_data_source == "http" ? local.data_source_content : null
   floppy_content = var.common_data_source == "disk" ? local.data_source_content : null
 
@@ -133,7 +134,7 @@ source "vsphere-iso" "linux-debian" {
       skip_import = var.common_content_library_skip_export
     }
   }
-  
+
   // OVF Export Settings
   dynamic "export" {
     for_each = var.common_ovf_export_enabled == true ? [1] : []

--- a/builds/linux/debian/11/variables.pkr.hcl
+++ b/builds/linux/debian/11/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/debian')"

--- a/builds/linux/photon/4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon/4/linux-photon.auto.pkrvars.hcl
@@ -25,6 +25,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/photon"
 iso_file           = "photon-4.0-c001795b8.iso"
 iso_checksum_type  = "md5"

--- a/builds/linux/photon/4/linux-photon.pkr.hcl
+++ b/builds/linux/photon/4/linux-photon.pkr.hcl
@@ -83,6 +83,7 @@ source "vsphere-iso" "linux-photon" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/photon/4/variables.pkr.hcl
+++ b/builds/linux/photon/4/variables.pkr.hcl
@@ -212,6 +212,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/photon')"

--- a/builds/linux/rhel/7/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/7/linux-rhel.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/rhel"
 iso_file           = "rhel-server-7.9-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -88,6 +88,7 @@ source "vsphere-iso" "linux-rhel" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rhel/7/variables.pkr.hcl
+++ b/builds/linux/rhel/7/variables.pkr.hcl
@@ -244,6 +244,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/rhel')"

--- a/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/rhel"
 iso_file           = "rhel-8.6-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -88,6 +88,7 @@ source "vsphere-iso" "linux-rhel" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rhel/8/variables.pkr.hcl
+++ b/builds/linux/rhel/8/variables.pkr.hcl
@@ -244,6 +244,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/rhel')"

--- a/builds/linux/rhel/9/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/9/linux-rhel.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/rhel"
 iso_file           = "rhel-baseos-9.0-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/rhel/9/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/9/linux-rhel.pkr.hcl
@@ -88,6 +88,7 @@ source "vsphere-iso" "linux-rhel" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rhel/9/variables.pkr.hcl
+++ b/builds/linux/rhel/9/variables.pkr.hcl
@@ -244,6 +244,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/rhel')"

--- a/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
+++ b/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/rocky"
 iso_file           = "Rocky-8.6-x86_64-dvd1.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-rocky" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rocky/8/variables.pkr.hcl
+++ b/builds/linux/rocky/8/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/rocky')"

--- a/builds/linux/rocky/9/linux-rocky.auto.pkrvars.hcl
+++ b/builds/linux/rocky/9/linux-rocky.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/rocky"
 iso_file           = "Rocky-9.0-x86_64-dvd.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-rocky" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/rocky/9/variables.pkr.hcl
+++ b/builds/linux/rocky/9/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/rocky')"

--- a/builds/linux/sles/15/linux-sles.auto.pkrvars.hcl
+++ b/builds/linux/sles/15/linux-sles.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/suse"
 iso_file           = "SLE-15-SP3-Full-x86_64-GM-Media1.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/sles/15/linux-sles.pkr.hcl
+++ b/builds/linux/sles/15/linux-sles.pkr.hcl
@@ -20,14 +20,14 @@ packer {
 //  Defines the local variables.
 
 locals {
-  build_by      = "Built by: HashiCorp Packer ${packer.version}"
-  build_date    = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
-  build_version = formatdate("YY.MM", timestamp())
+  build_by          = "Built by: HashiCorp Packer ${packer.version}"
+  build_date        = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
+  build_version     = formatdate("YY.MM", timestamp())
   build_description = "Version: v${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}"
   iso_paths         = ["[${var.common_iso_datastore}] ${var.iso_path}/${var.iso_file}"]
   iso_checksum      = "${var.iso_checksum_type}:${var.iso_checksum_value}"
-  manifest_date = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
-  manifest_path = "${path.cwd}/manifests/"
+  manifest_date     = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path     = "${path.cwd}/manifests/"
   manifest_output   = "${local.manifest_path}${local.manifest_date}.json"
   ovf_export_path   = "${path.cwd}/artifacts/${local.vm_name}"
   data_source_content = {
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-sles" {
 
   // Virtual Machine Settings
   guest_os_type        = var.vm_guest_os_type
-  vm_name              = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-v${local.build_version}"
+  vm_name              = local.vm_name
   firmware             = var.vm_firmware
   CPUs                 = var.vm_cpu_sockets
   cpu_cores            = var.vm_cpu_cores
@@ -85,11 +85,12 @@ source "vsphere-iso" "linux-sles" {
   vm_version           = var.common_vm_version
   remove_cdrom         = var.common_remove_cdrom
   tools_upgrade_policy = var.common_tools_upgrade_policy
-  notes                = "Version: v${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}"
+  notes                = local.build_description
 
   // Removable Media Settings
-  iso_paths    = ["[${var.common_iso_datastore}] ${var.iso_path}/${var.iso_file}"]
-  iso_checksum = "${var.iso_checksum_type}:${var.iso_checksum_value}"
+  iso_url      = var.iso_url
+  iso_paths    = local.iso_paths
+  iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null
   cd_content   = var.common_data_source == "disk" ? local.data_source_content : null
 
@@ -127,7 +128,7 @@ source "vsphere-iso" "linux-sles" {
     for_each = var.common_content_library_name != null ? [1] : []
     content {
       library     = var.common_content_library_name
-      description = "Version: v${local.build_version}\nBuilt on: ${local.build_date}\n${local.build_by}"
+      description = local.build_description
       ovf         = var.common_content_library_ovf
       destroy     = var.common_content_library_destroy
       skip_import = var.common_content_library_skip_export
@@ -181,7 +182,6 @@ build {
       vsphere_datastore        = var.vsphere_datastore
       vsphere_endpoint         = var.vsphere_endpoint
       vsphere_folder           = var.vsphere_folder
-      vsphere_iso_path         = "[${var.common_iso_datastore}] ${var.iso_path}/${var.iso_file}"
     }
   }
 }

--- a/builds/linux/sles/15/variables.pkr.hcl
+++ b/builds/linux/sles/15/variables.pkr.hcl
@@ -244,6 +244,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/suse')"

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/ubuntu"
 iso_file           = "ubuntu-18.04.6-server-amd64.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
@@ -86,6 +86,7 @@ source "vsphere-iso" "linux-ubuntu" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url        = var.iso_url
   iso_paths      = local.iso_paths
   iso_checksum   = local.iso_checksum
   http_content   = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/ubuntu/18-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/ubuntu')"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/ubuntu"
 iso_file           = "ubuntu-20.04.4-live-server-amd64.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -87,6 +87,7 @@ source "vsphere-iso" "linux-ubuntu" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/ubuntu')"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -28,6 +28,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/linux/ubuntu"
 iso_file           = "ubuntu-22.04-live-server-amd64.iso"
 iso_checksum_type  = "sha256"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -87,6 +87,7 @@ source "vsphere-iso" "linux-ubuntu" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   http_content = var.common_data_source == "http" ? local.data_source_content : null

--- a/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
@@ -230,6 +230,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/linux/ubuntu')"

--- a/builds/windows/desktop/10/variables.pkr.hcl
+++ b/builds/windows/desktop/10/variables.pkr.hcl
@@ -271,6 +271,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/windows')"

--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -37,6 +37,7 @@ vm_video_mem_size        = 131072
 vm_video_displays        = 1
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/windows/desktop"
 iso_file           = "en-us_windows_10_business_editions_version_21h1_updated_sep_2021_x64_dvd_56628c48.iso"
 iso_checksum_type  = "sha256"

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -83,6 +83,7 @@ source "vsphere-iso" "windows-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [

--- a/builds/windows/desktop/11/variables.pkr.hcl
+++ b/builds/windows/desktop/11/variables.pkr.hcl
@@ -277,6 +277,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/windows')"

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -38,6 +38,7 @@ vm_video_mem_size        = 131072
 vm_video_displays        = 1
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/windows/desktop"
 iso_file           = "en-us_windows_11_consumer_editions_updated_june_2022_x64_dvd_aec658b2.iso"
 iso_checksum_type  = "sha256"

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -84,6 +84,7 @@ source "vsphere-iso" "windows-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [

--- a/builds/windows/server/2019/variables.pkr.hcl
+++ b/builds/windows/server/2019/variables.pkr.hcl
@@ -298,6 +298,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/windows')"

--- a/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
@@ -42,6 +42,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/windows/server"
 iso_file           = "en-us_windows_server_2019_updated_aug_2021_x64_dvd_a6431a28.iso"
 iso_checksum_type  = "sha256"

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -84,6 +84,7 @@ source "vsphere-iso" "windows-server-standard-core" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -187,6 +188,7 @@ source "vsphere-iso" "windows-server-standard-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -290,6 +292,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -395,6 +398,7 @@ source "vsphere-iso" "windows-server-datacenter-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [

--- a/builds/windows/server/2022/variables.pkr.hcl
+++ b/builds/windows/server/2022/variables.pkr.hcl
@@ -298,6 +298,11 @@ variable "common_iso_datastore" {
   description = "The name of the source vSphere datastore for ISO images. (e.g. 'sfo-w01-cl01-nfs01')"
 }
 
+variable "iso_url" {
+  type        = string
+  description = "The URL source of the ISO image. (e.g. 'https://artifactory.rainpole.io/.../os.iso')"
+}
+
 variable "iso_path" {
   type        = string
   description = "The path on the source vSphere datastore for ISO image. (e.g. 'iso/windows')"

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -42,6 +42,7 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
+iso_url            = null
 iso_path           = "iso/windows/server"
 iso_file           = "en-us_windows_server_2022_updated_june_2022_x64_dvd_ac918027.iso"
 iso_checksum_type  = "sha256"

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -84,6 +84,7 @@ source "vsphere-iso" "windows-server-standard-core" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -187,6 +188,7 @@ source "vsphere-iso" "windows-server-standard-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -290,6 +292,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [
@@ -395,6 +398,7 @@ source "vsphere-iso" "windows-server-datacenter-desktop" {
   notes                = local.build_description
 
   // Removable Media Settings
+  iso_url      = var.iso_url
   iso_paths    = local.iso_paths
   iso_checksum = local.iso_checksum
   cd_files = [


### PR DESCRIPTION
## Summary of Pull Request

Add support for `iso_url` in the builder configuration blocks.

The project supports configuring the ISO from either a datastore or URL source. By default, the project uses the datastore source.

If you are using a URL source to obtain your guest operating system `.iso` files, you must update the input variables to use the URL source.

Update the `iso_url` variable to download the `.iso` from a URL. The `iso_url` variable takes presedence over any other `iso_*` variables.

  **Example**: `builds/<type>/<build>/*.auto.pkvars.hcl`

```hcl
iso_url = "https://artifactory.rainpole.io/iso/linux/photon/4.0/x86_64/photon-4.0-xxxxxxxxx.iso"
```


Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of Pull Request

- [ ] This is a bugfix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes: #235

## Test and Documentation Coverage

- [x] Tests have been completed (for bugfixes / features).
- [x] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.