### PR TITLE
chore(deps): bump .iso to August 2022 revisions for Windows guest operating systems

### DIFF
--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -39,9 +39,9 @@ vm_video_displays        = 1
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_10_business_editions_version_21h1_updated_sep_2021_x64_dvd_56628c48.iso"
+iso_file           = "en-us_windows_10_business_editions_version_21h1_updated_aug_2022_x64_dvd_b3dc85d2.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "852C6A57D1660D2FF0745EBE16DC6CF1AAA67FC7C608C06921082403BACC6285"
+iso_checksum_value = "BC0278961FDB5219C647C20119734389EDC43BB3933B3BE804F8B9C5B2A45A1B"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -40,9 +40,9 @@ vm_video_displays        = 1
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_11_consumer_editions_updated_june_2022_x64_dvd_aec658b2.iso"
+iso_file           = "en-us_windows_11_business_editions_version_21h2_updated_aug_2022_x64_dvd_50c9cab3.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "E2A671BAE4CA80A094A4D7932353135E3A24050902662CA3CC2E950C73B85D43"
+iso_checksum_value = "8B5FE1C2FDB14BD9561460D976E9040FBB7B3CEEDF9DD20FFA1CD9984C6286A0"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -44,9 +44,9 @@ vm_network_card          = "vmxnet3"
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/windows/server"
-iso_file           = "en-us_windows_server_2022_updated_june_2022_x64_dvd_ac918027.iso"
+iso_file           = "en-us_windows_server_2022_updated_aug_2022_x64_dvd_8b65e57f.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "D98E02D7324F2FAD404C6822A11D83A052A3F2BB0F94D10BEFBA64EE0BB2AC4F"
+iso_checksum_value = "880C7F6E7818B396EE66AF8B1A3D86BB57810EA2FD6AE447F4D5124340076609"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
## Summary of Pull Request

Update the following based on August 2022 updates:

### Windows Server 2022
Released: 8/16/2022
SHA256: `880C7F6E7818B396EE66AF8B1A3D86BB57810EA2FD6AE447F4D5124340076609`
File name: `en-us_windows_server_2022_updated_aug_2022_x64_dvd_8b65e57f.iso`

### Windows 11
Released: 8/16/2022
SHA256: `8B5FE1C2FDB14BD9561460D976E9040FBB7B3CEEDF9DD20FFA1CD9984C6286A0`
File name: `en-us_windows_11_business_editions_version_21h2_updated_aug_2022_x64_dvd_50c9cab3.iso`

### Windows 10
Released: 8/16/2022
SHA256: `BC0278961FDB5219C647C20119734389EDC43BB3933B3BE804F8B9C5B2A45A1B`
File name: `en-us_windows_10_business_editions_version_21h1_updated_aug_2022_x64_dvd_b3dc85d2.iso`

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is something else.
      Please describe: `chore`

## Related to Existing Issues

Closes: #250

## Test and Documentation Coverage

- [x] Tests have been completed (for bugfixes / features).
- [x] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
