### PR TITLE
fix: update `vm_cpu_sockets` to `vm_cpu_count` for CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,10 +850,11 @@ rainpole@macos> . ./set-envvars.sh
 
 Edit the `*.auto.pkvars.hcl` file in each `builds/<type>/<build>` folder to configure the following virtual machine hardware settings, as required:
 
-* CPU Sockets `(int)`
+* CPUs `(int)`
 * CPU Cores `(int)`
 * Memory in MB `(int)`
 * Primary Disk in MB `(int)`
+* .iso URL `(string)`
 * .iso Path `(string)`
 * .iso File `(string)`
 * .iso Checksum Type `(string)`

--- a/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other4xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-almalinux" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -183,7 +183,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/almalinux/8/variables.pkr.hcl
+++ b/builds/linux/almalinux/8/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/almalinux/9/linux-almalinux.auto.pkrvars.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other5xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-almalinux" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -182,7 +182,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/almalinux/9/variables.pkr.hcl
+++ b/builds/linux/almalinux/9/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/centos/7/linux-centos.auto.pkrvars.hcl
+++ b/builds/linux/centos/7/linux-centos.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "centos7_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-centos" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -181,7 +181,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/centos/7/variables.pkr.hcl
+++ b/builds/linux/centos/7/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "centos8_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-centos-stream" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -181,7 +181,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/centos/8-stream/variables.pkr.hcl
+++ b/builds/linux/centos/8-stream/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/centos/9-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other5xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-centos-stream" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -182,7 +182,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/centos/9-stream/variables.pkr.hcl
+++ b/builds/linux/centos/9-stream/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
+++ b/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other4xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/debian/11/linux-debian.pkr.hcl
+++ b/builds/linux/debian/11/linux-debian.pkr.hcl
@@ -64,7 +64,7 @@ source "vsphere-iso" "linux-debian" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -183,7 +183,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/debian/11/variables.pkr.hcl
+++ b/builds/linux/debian/11/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/photon/4/linux-photon.auto.pkrvars.hcl
+++ b/builds/linux/photon/4/linux-photon.auto.pkrvars.hcl
@@ -14,7 +14,7 @@ vm_guest_os_type = "vmwarePhoton64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/photon/4/linux-photon.pkr.hcl
+++ b/builds/linux/photon/4/linux-photon.pkr.hcl
@@ -62,7 +62,7 @@ source "vsphere-iso" "linux-photon" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -180,7 +180,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/photon/4/variables.pkr.hcl
+++ b/builds/linux/photon/4/variables.pkr.hcl
@@ -92,9 +92,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/rhel/7/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/7/linux-rhel.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "rhel7_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -67,7 +67,7 @@ source "vsphere-iso" "linux-rhel" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -183,7 +183,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/rhel/7/variables.pkr.hcl
+++ b/builds/linux/rhel/7/variables.pkr.hcl
@@ -124,9 +124,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/8/linux-rhel.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "rhel8_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -67,7 +67,7 @@ source "vsphere-iso" "linux-rhel" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -183,7 +183,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/rhel/8/variables.pkr.hcl
+++ b/builds/linux/rhel/8/variables.pkr.hcl
@@ -124,9 +124,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/rhel/9/linux-rhel.auto.pkrvars.hcl
+++ b/builds/linux/rhel/9/linux-rhel.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "rhel9_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/rhel/9/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/9/linux-rhel.pkr.hcl
@@ -67,7 +67,7 @@ source "vsphere-iso" "linux-rhel" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -184,7 +184,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/rhel/9/variables.pkr.hcl
+++ b/builds/linux/rhel/9/variables.pkr.hcl
@@ -124,9 +124,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
+++ b/builds/linux/rocky/8/linux-rocky.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other4xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-rocky" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -181,7 +181,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/rocky/8/variables.pkr.hcl
+++ b/builds/linux/rocky/8/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/rocky/9/linux-rocky.auto.pkrvars.hcl
+++ b/builds/linux/rocky/9/linux-rocky.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "other5xLinux64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-rocky" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -182,7 +182,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/rocky/9/variables.pkr.hcl
+++ b/builds/linux/rocky/9/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/sles/15/linux-sles.auto.pkrvars.hcl
+++ b/builds/linux/sles/15/linux-sles.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "sles15_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/sles/15/linux-sles.pkr.hcl
+++ b/builds/linux/sles/15/linux-sles.pkr.hcl
@@ -67,7 +67,7 @@ source "vsphere-iso" "linux-sles" {
   guest_os_type        = var.vm_guest_os_type
   vm_name              = local.vm_name
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -170,7 +170,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/sles/15/variables.pkr.hcl
+++ b/builds/linux/sles/15/variables.pkr.hcl
@@ -124,9 +124,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "ubuntu64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/linux-ubuntu.pkr.hcl
@@ -65,7 +65,7 @@ source "vsphere-iso" "linux-ubuntu" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -189,7 +189,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/ubuntu/18-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/18-04-lts/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "ubuntu64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -66,7 +66,7 @@ source "vsphere-iso" "linux-ubuntu" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -185,7 +185,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.auto.pkrvars.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.auto.pkrvars.hcl
@@ -17,7 +17,7 @@ vm_guest_os_type = "ubuntu64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 2048

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -66,7 +66,7 @@ source "vsphere-iso" "linux-ubuntu" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -185,7 +185,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
@@ -110,9 +110,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/windows/desktop/10/variables.pkr.hcl
+++ b/builds/windows/desktop/10/variables.pkr.hcl
@@ -139,9 +139,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -24,7 +24,7 @@ vm_guest_os_type = "windows9_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 4096

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -60,7 +60,7 @@ source "vsphere-iso" "windows-desktop" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -194,7 +194,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/windows/desktop/11/variables.pkr.hcl
+++ b/builds/windows/desktop/11/variables.pkr.hcl
@@ -139,9 +139,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -24,7 +24,7 @@ vm_guest_os_type = "windows9_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 4096

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -60,7 +60,7 @@ source "vsphere-iso" "windows-desktop" {
   vm_name              = local.vm_name
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -196,7 +196,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/windows/server/2019/variables.pkr.hcl
+++ b/builds/windows/server/2019/variables.pkr.hcl
@@ -178,9 +178,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
@@ -31,7 +31,7 @@ vm_guest_os_type = "windows2019srv_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 4096

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -63,7 +63,7 @@ source "vsphere-iso" "windows-server-standard-core" {
   vm_name              = local.vm_name_standard_core
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -166,7 +166,7 @@ source "vsphere-iso" "windows-server-standard-desktop" {
   vm_name              = local.vm_name_standard_desktop
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -270,7 +270,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   vm_name              = local.vm_name_datacenter_core
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -376,7 +376,7 @@ source "vsphere-iso" "windows-server-datacenter-desktop" {
   vm_name              = local.vm_name_datacenter_desktop
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -512,7 +512,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware

--- a/builds/windows/server/2022/variables.pkr.hcl
+++ b/builds/windows/server/2022/variables.pkr.hcl
@@ -178,9 +178,9 @@ variable "vm_cdrom_type" {
   default     = "sata"
 }
 
-variable "vm_cpu_sockets" {
+variable "vm_cpu_count" {
   type        = number
-  description = "The number of virtual CPUs sockets. (e.g. '2')"
+  description = "The number of virtual CPUs. (e.g. '2')"
 }
 
 variable "vm_cpu_cores" {

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -31,7 +31,7 @@ vm_guest_os_type = "windows2019srvNext_64Guest"
 // Virtual Machine Hardware Settings
 vm_firmware              = "efi-secure"
 vm_cdrom_type            = "sata"
-vm_cpu_sockets           = 2
+vm_cpu_count             = 2
 vm_cpu_cores             = 1
 vm_cpu_hot_add           = false
 vm_mem_size              = 4096

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -63,7 +63,7 @@ source "vsphere-iso" "windows-server-standard-core" {
   vm_name              = local.vm_name_standard_core
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -166,7 +166,7 @@ source "vsphere-iso" "windows-server-standard-desktop" {
   vm_name              = local.vm_name_standard_desktop
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -270,7 +270,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   vm_name              = local.vm_name_datacenter_core
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -376,7 +376,7 @@ source "vsphere-iso" "windows-server-datacenter-desktop" {
   vm_name              = local.vm_name_datacenter_desktop
   guest_os_type        = var.vm_guest_os_type
   firmware             = var.vm_firmware
-  CPUs                 = var.vm_cpu_sockets
+  CPUs                 = var.vm_cpu_count
   cpu_cores            = var.vm_cpu_cores
   CPU_hot_plug         = var.vm_cpu_hot_add
   RAM                  = var.vm_mem_size
@@ -512,7 +512,7 @@ build {
       common_data_source       = var.common_data_source
       common_vm_version        = var.common_vm_version
       vm_cpu_cores             = var.vm_cpu_cores
-      vm_cpu_sockets           = var.vm_cpu_sockets
+      vm_cpu_count             = var.vm_cpu_count
       vm_disk_size             = var.vm_disk_size
       vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
       vm_firmware              = var.vm_firmware


### PR DESCRIPTION
## Summary of Pull Request

Updates `vm_cpu_sockets` to `vm_cpu_count` for CPUs. The project currently uses the variable `vm_cpu_sockets`  for CPUs (see below); however, the value of the sockets is determined by dividing the number of CPUs by the number of cores per socket.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of Pull Request

- [x] This is a bugfix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes: #252

## Test and Documentation Coverage

- [x] Tests have been completed (for bugfixes / features).
- [x] Documentation has been added / updated (for bugfixes / features).

## Breaking Changes?

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.
