### PR TITLE
fix: add support for disk-based deployment mode for Debian 11

### DIFF
--- a/builds/linux/debian/11/data/ks.pkrtpl.hcl
+++ b/builds/linux/debian/11/data/ks.pkrtpl.hcl
@@ -176,3 +176,9 @@ d-i pkgsel/include string openssh-server open-vm-tools python3-apt perl
 d-i preseed/late_command string \
     echo '${build_username} ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/${build_username} ; \
     in-target chmod 440 /etc/sudoers.d/${build_username} ;
+
+%{ if common_data_source == "disk" ~}
+# Umount preseed media early
+d-i preseed/early_command string \
+    umount /media && echo 1 > /sys/block/sr1/device/delete ;
+%{ endif ~}

--- a/builds/linux/debian/11/linux-debian.pkr.hcl
+++ b/builds/linux/debian/11/linux-debian.pkr.hcl
@@ -37,6 +37,7 @@ locals {
       vm_guest_os_language     = var.vm_guest_os_language
       vm_guest_os_keyboard     = var.vm_guest_os_keyboard
       vm_guest_os_timezone     = var.vm_guest_os_timezone
+      common_data_source       = var.common_data_source
     })
   }
   data_source_command = var.common_data_source == "http" ? "url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "file=/media/ks.cfg"
@@ -91,7 +92,7 @@ source "vsphere-iso" "linux-debian" {
   iso_paths      = local.iso_paths
   iso_checksum   = local.iso_checksum
   http_content   = var.common_data_source == "http" ? local.data_source_content : null
-  floppy_content = var.common_data_source == "disk" ? local.data_source_content : null
+  cd_content     = var.common_data_source == "disk" ? local.data_source_content : null
 
   // Boot and Provisioning Settings
   http_ip       = var.common_data_source == "http" ? var.common_http_ip : null
@@ -107,7 +108,15 @@ source "vsphere-iso" "linux-debian" {
     " ${local.data_source_command}",
     " noprompt --<enter>",
     "initrd /install.amd/initrd.gz<enter>",
-    "boot<enter>"
+    "boot<enter>",
+    "<wait30s>",
+    "<enter><wait>",
+    "<enter><wait>",
+    "<leftAltOn><f2><leftAltOff>",
+    "<enter><wait>",
+    "mount /dev/sr1 /media<enter>",
+    "<leftAltOn><f1><leftAltOff>",
+    "<down><down><down><down><enter>"
   ]
   ip_wait_timeout  = var.common_ip_wait_timeout
   shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Debian 11 was introduced to the project in the v22.08 release with only support for HTTP-based deployment only.

This PR will add the enhancement for disk-based deployment support and fix issue #261 as discussed with @tenthirtyam in comments.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)? 
  
  For example: 
  - Resolves #1234
-->

- Resolves #261 

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

The `boot_command` and the `preseed/early_command` are determined based on the configuration in the common_data_source variable.

Here is the output of the whole boot sequence with the `common_data_source` variable set to `disk`:
![data_source_disk](https://user-images.githubusercontent.com/73410869/191134410-ac08963f-8f16-4a0d-a487-bf9aabeaa95b.gif)


And here is a screenshot of the boot command with the `common_data_source` variable set to `http`:
<img width="1182" alt="data_source_http" src="https://user-images.githubusercontent.com/73410869/191134142-ab20690a-7bf7-4fcc-9bf3-28008125a041.png">



## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
