### PR TITLE
chore(deps): bump windows 10 to 21h2 september 2022

### DIFF
--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -39,9 +39,9 @@ vm_video_displays        = 1
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_10_business_editions_version_21h1_updated_aug_2022_x64_dvd_b3dc85d2.iso"
+iso_file           = "en-us_windows_10_business_editions_version_21h2_updated_sep_2022_x64_dvd_c9733841.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "BC0278961FDB5219C647C20119734389EDC43BB3933B3BE804F8B9C5B2A45A1B"
+iso_checksum_value = "1B72D486C3ABB89E0859970D5325163D289D82BB45D577A9A88536029B79FDAA"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Windows 10 to the 21H2 September 2022 release.

Signed-off-by: Ryan Johnson johnsonryan@vmware.com


## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)? 
  
  For example: 
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
