### PR TITLE
chore(deps): bump centos stream 8 to latest

### DIFF
--- a/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.auto.pkrvars.hcl
@@ -30,9 +30,9 @@ vm_network_card          = "vmxnet3"
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/linux/centos"
-iso_file           = "CentOS-Stream-8-x86_64-latest-dvd1.iso"
+iso_file           = "CentOS-Stream-8-x86_64-20221027-dvd1.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "9675a47b19054090dd49431a66d3f7b6fc15a755c4af0b56e6b0c32221870a14"
+iso_checksum_value = "7134a1d325e869abf676bba899e038220bd91a3632af28889eccc129f24c0dc9"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps CentOS Stream 8 to the October 2022 release.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
