### PR TITLE
feat: Allow SSH authentication with RSA keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Operating systems and versions tested with the project:
 - Ubuntu Server 22.04 LTS and 20.04 LTS (`x86_64`)
 - macOS Monterey and Big Sur (Intel)
 
+> **Note**
+>
+> If your [Ansible][ansible-ssh-connection] control node already uses OpenSSH >= 9.0 you must add an additional option to enable scp (scp_extra_args="-O").
+>
+> Update the `packer-examples-for-vsphere/ansible/ansible.cfg` to include the following:
+>
+> `[ssh_connection]` \
+> `scp_extra_args = "-O"`
+
 **Packer**:
 
 - HashiCorp [Packer][packer-install] 1.8.4 or higher.
@@ -976,6 +985,7 @@ Happy building!!!
 
 [//]: Links
 [ansible-docs]: https://docs.ansible.com
+[ansible-ssh-connection]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ssh_connection.html#parameter-scp_if_ssh
 [cloud-init]: https://cloudinit.readthedocs.io/en/latest/
 [credits-owen-reynolds-twitter]: https://twitter.com/OVDamn
 [credits-owen-reynolds-github]: https://github.com/getvpro/Build-Packer/blob/master/Scripts/Install-VMTools.ps1

--- a/README.md
+++ b/README.md
@@ -67,15 +67,6 @@ Operating systems and versions tested with the project:
 - Ubuntu Server 22.04 LTS and 20.04 LTS (`x86_64`)
 - macOS Monterey and Big Sur (Intel)
 
-> **Note**
->
-> Update your `/etc/ssh/ssh_config` or `~/.ssh/ssh_config` to allow ssh authentication with RSA keys if you are using VMware Photon OS 4.0 or Ubuntu 22.04.
->
-> Update to include the following:
->
-> `HostKeyAlgorithms +ssh-rsa`
-> `PubKeyAcceptedAlgorithms +ssh-rsa`
-
 **Packer**:
 
 - HashiCorp [Packer][packer-install] 1.8.4 or higher.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,3 +1,6 @@
 [defaults]
 display_skipped_hosts = false
 ansible_python_interpreter = /usr/bin/python3
+
+[ssh_connection]
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa


### PR DESCRIPTION
## Summary of Pull Request

Adds `HostKeyAlgorithms=+ssh-rsa` and `PubkeyAcceptedKeyTypes=+ssh-rsa` as extra arguments for Ansible.

This will set these parameters automatically instead of assuming that the user has read the current documented requirements. 

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

I have tested this for Debian 11 and Ubuntu Server 22.04 LTS. VMware Photon OS 4 did not get pass the boot loader. 

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
