### PR TITLE
chore(deps): bump windows server 2022 to latest

### DIFF
--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -44,9 +44,9 @@ vm_network_card          = "vmxnet3"
 // Removable Media Settings
 iso_url            = null
 iso_path           = "iso/windows/server"
-iso_file           = "en-us_windows_server_2022_updated_oct_2022_x64_dvd_c5b651c9.iso"
+iso_file           = "en-us_windows_server_2022_updated_nov_2022_x64_dvd_8d436d40.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "97B88B36B2DD55A173C08FE9D92B5EB978485D3B1500D831EB9A57885D697FEE"
+iso_checksum_value = "AF1EAD71DB0986B614ADFBEF6D9A866B9DBCCE0482E928E4209787E7599C31A7"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Windows Server 2022 to November 2022 release.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
