### PR TITLE
fix: remove country code for ubuntu

### DIFF
--- a/builds/linux/ubuntu/20-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu/20-04-lts/data/user-data.pkrtpl.hcl
@@ -14,7 +14,7 @@ autoinstall:
     preserve_sources_list: false
     primary:
       - arches: [amd64, i386]
-        uri: http://us.archive.ubuntu.com/ubuntu
+        uri: http://archive.ubuntu.com/ubuntu
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
   early-commands:

--- a/builds/linux/ubuntu/22-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu/22-04-lts/data/user-data.pkrtpl.hcl
@@ -14,7 +14,7 @@ autoinstall:
     preserve_sources_list: false
     primary:
       - arches: [amd64, i386]
-        uri: http://us.archive.ubuntu.com/ubuntu
+        uri: http://archive.ubuntu.com/ubuntu
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
   early-commands:


### PR DESCRIPTION
## Summary of Pull Request

The ```uri``` should not contain a country code like ```us```. Otherwise the GeoIP lookup does not work. 

```
deb http://us.archive.ubuntu.com/ubuntu jammy main restricted
vs
deb http://de.archive.ubuntu.com/ubuntu jammy main restricted
```

https://github.com/canonical/subiquity/blob/main/documentation/autoinstall-reference.md?plain=1#L214

## Type of Pull Request

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

