### PR TITLE
feat: enhance winrm configuration

### DIFF
--- a/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
@@ -56,7 +56,7 @@ vm_boot_command     = ["<spacebar>"]
 vm_shutdown_command = "shutdown /s /t 10 /f /d p:4:1 /c \"Shutdown by Packer\""
 
 // Communicator Settings
-communicator_port    = 5985
+communicator_port    = 5986
 communicator_timeout = "12h"
 
 // Provisioner Settings

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -134,6 +134,9 @@ source "vsphere-iso" "windows-server-standard-core" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -240,6 +243,9 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -348,6 +354,9 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -454,6 +463,9 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -56,7 +56,7 @@ vm_boot_command     = ["<spacebar>"]
 vm_shutdown_command = "shutdown /s /t 10 /f /d p:4:1 /c \"Shutdown by Packer\""
 
 // Communicator Settings
-communicator_port    = 5985
+communicator_port    = 5986
 communicator_timeout = "12h"
 
 // Provisioner Settings

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -134,6 +134,9 @@ source "vsphere-iso" "windows-server-standard-core" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -240,6 +243,9 @@ source "vsphere-iso" "windows-server-standard-dexp" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -348,6 +354,9 @@ source "vsphere-iso" "windows-server-datacenter-core" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion
@@ -454,6 +463,9 @@ source "vsphere-iso" "windows-server-datacenter-dexp" {
   winrm_password = var.build_password
   winrm_port     = var.communicator_port
   winrm_timeout  = var.communicator_timeout
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
 
   // Template and Content Library Settings
   convert_to_template = var.common_template_conversion

--- a/scripts/windows/windows-init.ps1
+++ b/scripts/windows/windows-init.ps1
@@ -1,33 +1,151 @@
-# Copyright 2023 VMware, Inc. All rights reserved.
-# SPDX-License-Identifier: BSD-2
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 <#
     .DESCRIPTION
-    Enables Windows Remote Management on Windows builds.
+    Windows Remote Management configuration initialization.
 #>
 
 $ErrorActionPreference = 'Stop'
 
-# Set network connections provile to Private mode.
-Write-Output 'Setting the network connection profiles to Private...'
-$connectionProfile = Get-NetConnectionProfile
-While ($connectionProfile.Name -eq 'Identifying...') {
-    Start-Sleep -Seconds 10
-    $connectionProfile = Get-NetConnectionProfile
+$firewallGroupName = 'Windows Remote Management'
+$httpFirewallRuleDisplayName = 'Windows Remote Management (HTTP-In)'
+$httpsFirewallRuleName = 'WINRM-HTTPS-In-TCP'
+$httpsFirewallRuleDisplayName = 'Windows Remote Management (HTTPS-In)'
+$httpsFirewallRuleDescription = 'Windows Remote Management Inbound HTTPS [TCP 5986]'
+$httpsFirewallRuleProgram = 'System'
+$httpsFirewallRuleAction = 'Allow'
+$httpsFirewallRuleEnabled = 'False'
+$httpsPort = 5986
+$protocol = 'TCP'
+$transport = 'HTTPS'
+
+$logDirectory = 'C:\Packer'
+$logFile = 'C:\windows-winrm-init.log'
+
+# Start the Windows Remote Management configuration initialization logging.
+Start-Transcript -Path $logFile -Force
+Write-Output 'Starting the Windows Remote Management configuration initialization logging...'
+
+# Start the Windows Remote Management configuration initialization.
+Write-Output 'Starting the Windows Remote Management configuration initialization...'
+
+# Get the operating system information.
+Write-Output 'Getting the operating system information...'
+$osType = (Get-CimInstance -ClassName Win32_OperatingSystem).InstallationType.ToLower()
+Write-Output "Operating system type: $osType"
+
+# Disable the Network Location Wizard.
+Write-Output 'Disabling the Network Location Wizard...'
+New-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff' -Force | Out-Null
+
+# Set network connections profile to private.
+Write-Output 'Setting the network connection profiles to private...'
+Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private -Verbose
+
+if ($osType -eq 'client') {
+    # Set the Windows Remote Management on Windows Desktop configuration
+    Write-Output 'Setting the Windows Remote Management on Windows Desktop configuration initialization...'
+    Write-Output 'This configuration will be removed during the build cleanup.'
+    Enable-PSRemoting -SkipNetworkProfileCheck -Force
+    $wsmanConfig = @{
+        'winrm/config' = @{MaxTimeoutms = 18000};
+        'winrm/config/winrs' = @{MaxMemoryPerShellMB = 1024};
+        'winrm/config/service' = @{AllowUnencrypted = 'true'};
+        'winrm/config/service/auth' = @{Negotiate = 'true'};
+    }
+    foreach ($entry in $wsmanConfig.GetEnumerator()) {
+        Set-WSManInstance -ResourceURI $entry.Name -ValueSet $entry.Value
+    }
+
+    # Allow Windows Remote Management in the Windows Firewall.
+    Write-Output 'Allowing Windows Remote Management in the Windows Firewall...'
+    Enable-NetFirewallRule -DisplayGroup $firewallGroupName -PassThru |
+    Get-NetFirewallRule -DisplayGroup $firewallGroupName |
+    Get-NetFirewallAddressFilter |
+    Where-Object { $_.RemoteAddress -Like 'LocalSubnet*' } |
+    Get-NetFirewallRule |
+    Set-NetFirewallRule -RemoteAddress Any |
+    Set-NetFirewallRule -DisplayName $httpFirewallRuleDisplayName -EdgeTraversalPolicy Allow -Confirm:$false
+} elseif (($osType -eq 'server') -or ($osType -eq 'server core')) {
+    # Add the Windows Remote Management HTTPS listeners.
+    Write-Output 'Adding the Windows Remote Management HTTPS listeners...'
+    $certificate = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My -DnsName $env:COMPUTERNAME
+    New-Item -Path WSMan:\LocalHost\Listener -Transport $transport -Address * -CertificateThumbPrint $certificate.Thumbprint -Hostname $env:COMPUTERNAME -Port $httpsPort -Force | Out-Null
+
+    # Set the Windows Remote Management trusted hosts to all.
+    Write-Output 'Setting the Windows Remote Management trusted hosts to all...'
+    Set-Item -Path WSMan:\localhost\Client/TrustedHosts -Value * -Force
+
+    # Remove the default Windows Remote Management HTTP listener.
+    Write-Output 'Removing the default Windows Remote Management HTTP listener...'
+    Get-ChildItem WSMan:\localhost\Listener | Where-Object { $_.Keys -contains 'Transport=HTTP' } | Remove-Item -Recurse -Confirm:$false
+
+    # Set the Windows Remote Management NTLM authentication configuration.
+    Write-Output 'Setting the Windows Remote Management NTLM authentication configuration...'
+    $ntlmConfig = @{
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' = @{ 'LmCompatibilityLevel' = 2 };
+        'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0' = @{ 'NTLMMinServerSec' = 536870912 };
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' = @{ 'LocalAccountTokenFilterPolicy' = 1 };
+    }
+    foreach ($entry in $ntlmConfig.GetEnumerator()) {
+        Set-ItemProperty -Path $entry.Name -Name $entry.Value.Keys -Value $entry.Value.Values -Type DWord -Force
+    }
+
+    # Disable the default Windows Remote Management firewall group rules.
+    Write-Output 'Disabling the default Windows Remote Management firewall group rules...'
+    Disable-NetFirewallRule -DisplayGroup $firewallGroupName
+
+    # Set the Windows Remote Management over Inbound HTTPS on TCP 5986 firewall rule.
+    Write-Output 'Setting the Windows Remote Management over Inbound HTTPS on TCP 5986 firewall rule...'
+    New-NetFirewallRule `
+        -Name $httpsFirewallRuleName `
+        -DisplayName $httpsFirewallRuleDisplayName `
+        -Description $httpsFirewallRuleDescription `
+        -Group $firewallGroupName `
+        -Program $httpsFirewallRuleProgram `
+        -Protocol $protocol `
+        -LocalPort $httpsPort `
+        -Action $httpsFirewallRuleAction `
+        -Enabled $httpsFirewallRuleEnabled -ErrorAction SilentlyContinue
+
+    # Enable Windows Remote Management over HTTPS in the Windows Firewall.
+    Write-Output 'Enabling Windows Remote Management over HTTPS in the Windows Firewall...'
+    Enable-NetFirewallRule -DisplayName $httpsFirewallRuleDisplayName -ErrorAction SilentlyContinue
 }
-Set-NetConnectionProfile -Name $connectionProfile.Name -NetworkCategory Private
 
-# Set the Windows Remote Management configuration.
-Write-Output 'Setting the Windows Remote Management configuration...'
-winrm quickconfig -quiet
-winrm set winrm/config/service '@{AllowUnencrypted="true"}'
-winrm set winrm/config/service/auth '@{Basic="true"}'
+# Set the AutoLogonCount to 0.
+Write-Output 'Setting the AutoLogonCount to 0...'
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name 'AutoLogonCount' -Value 0 -Force
 
-# Allow Windows Remote Management in the Windows Firewall.
-Write-Output 'Allowing Windows Remote Management in the Windows Firewall...'
-netsh advfirewall firewall set rule group="Windows Remote Administration" new enable=yes
-netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow
+# Stop the Windows Remote Management configuration initialization logging.
+Write-Output 'Stopping the Windows Remote Management configuration initialization logging...'
+Stop-Transcript
 
-# Reset the autologon count.
-# Reference: https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-autologon-logoncount#logoncount-known-issue
-Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name AutoLogonCount -Value 0
+# Save the Windows Remote Management configuration initilization log.
+Write-Output 'Saving the Windows Remote Management configuration initilization log...'
+try {
+    New-Item -Path $logDirectory -Type Directory -Force | Out-Null
+    $acl = Get-Acl $logDirectory
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule('Administrators', 'FullControl', 'ContainerInherit,Objectinherit', 'none', 'Allow')
+    $acl.AddAccessRule($rule)
+    Set-Acl -Path $logDirectory -AclObject $acl
+} catch {
+    Write-Output "Failed to set ACL for '$logDirectory': $_"
+    exit 1
+}
+
+# Move the Windows Remote Management configuration initilization log.
+Write-Output 'Moving the Windows Remote Management configuration initilization log...'
+try {
+    Move-Item -Path $logFile -Destination $logDirectory -Force -ErrorAction Stop
+} catch {
+    Write-Output "Failed to move log file: $_"
+    exit 1
+}
+
+# Windows Remote Management configuration completed.
+Write-Output 'Windows Remote Management configuration initialization completed.'
+

--- a/scripts/windows/windows-prepare.ps1
+++ b/scripts/windows/windows-prepare.ps1
@@ -12,58 +12,86 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Optional: Import the Root CA certificate to the Trusted Root Certification Authorities.
-# This option will require the use of a file provisioner to copy the certificate to the guest.
-# Write-Output "Importing the Root CA certificate to the Trusted Root Certification Authorities..."
-# Import-Certificate -FilePath C:\windows\temp\root-ca.cer -CertStoreLocation 'Cert:\LocalMachine\Root' | Out-Null
-# Remove-Item C:\windows\temp\root-ca.cer -Confirm:$false
+function Set-RegistryValue {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Path,
+        [Parameter(Mandatory=$true)] [string]$Name,
+        [Parameter(Mandatory=$true)] [string]$Value
+    )
 
-# Optional: Import the Issuing CA certificate to the Trusted Root Certification Authoriries.
-# This option will require the use of a file provisioner to copy the certificate to the guest.
-# Write-Output "Importing the Issuing CA certificate to the Trusted Root Certification Authoriries..."
-# Import-Certificate -FilePath C:\windows\temp\issuing-ca.cer -CertStoreLocation 'Cert:\LocalMachine\CA' | Out-Null
-# Remove-Item C:\windows\temp\issuing-ca.cer -Confirm:$false
+    Set-ItemProperty -Path $Path -Name $Name -Value $Value | Out-Null
+}
+
+function Disable-TLS {
+    param (
+        [Parameter(Mandatory=$true)] [string]$Version
+    )
+
+    Write-Output "Disabling TLS $Version..."
+    $path = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS $Version"
+
+    if (-not (Test-Path $path)) {
+        New-Item -Path $path -Force | Out-Null
+        New-Item -Path "$path\Server" -Force | Out-Null
+        New-Item -Path "$path\Client" -Force | Out-Null
+        Set-RegistryValue -Path "$path\Client" -Name "Enabled" -Value 0
+        Set-RegistryValue -Path "$path\Client" -Name "DisabledByDefault" -Value 1
+        Set-RegistryValue -Path "$path\Server" -Name "Enabled" -Value 0
+        Set-RegistryValue -Path "$path\Server" -Name "DisabledByDefault" -Value 1
+    }
+}
 
 # Set the Windows Explorer options.
-Write-Output "Setting the Windows Explorer options..."
-Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "Hidden" -Value 1 | Out-Null
-Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt" -Value 0 | Out-Null
-Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideDrivesWithNoMedia" -Value 0 | Out-Null
-Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "ShowSyncProviderNotifications" -Value 0 | Out-Null
+Write-Output "Setting Windows Explorer options..."
+$explorerOptions = @{
+    "Hidden" = 1
+    "HideFileExt" = 0
+    "HideDrivesWithNoMedia" = 0
+    "ShowSyncProviderNotifications" = 0
+}
+foreach ($option in $explorerOptions.GetEnumerator()) {
+    Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name $option.Name -Value $option.Value
+}
 
 # Disable system hibernation.
 Write-Output "Disabling system hibernation..."
-Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Power\" -Name "HiberFileSizePercent" -Value 0 | Out-Null
-Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Power\" -Name "HibernateEnabled" -Value 0 | Out-Null
+$hibernationOptions = @{
+    "HiberFileSizePercent" = 0
+    "HibernateEnabled" = 0
+}
+foreach ($option in $hibernationOptions.GetEnumerator()) {
+    Set-RegistryValue -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Power" -Name $option.Name -Value $option.Value
+}
 
-# Disable TLS 1.0.s
-Write-Output "Disabling TLS 1.0..."
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols" -Name "TLS 1.0" | Out-Null
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0" -Name "Server" | Out-Null
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0" -Name "Client" | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" -Name "Enabled" -Value 0 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" -Name "DisabledByDefault" -Value 1 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server" -Name "Enabled" -Value 0 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server" -Name "DisabledByDefault" -Value 1 | Out-Null
-
-# Disable TLS 1.1.
-Write-Output "Disabling TLS 1.1..."
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols" -Name "TLS 1.1" | Out-Null
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1" -Name "Server" | Out-Null
-New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1" -Name "Client" | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client" -Name "Enabled" -Value 0 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client" -Name "DisabledByDefault" -Value 1 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" -Name "Enabled" -Value 0 | Out-Null
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" -Name "DisabledByDefault" -Value 1 | Out-Null
+# Disable TLS 1.0 and 1.1
+Disable-TLS -Version "1.0"
+Disable-TLS -Version "1.1"
 
 # Disable Password Expiration for the Administrator Accounts - (Administrator and Build)
-Write-Output "Disabling password expiration for the local Administrator accounts..."
-$localAdministrator = (Get-LocalUser | Where-Object { $_.sid -like '*-500' }).name
-Set-LocalUser -Name $localAdministrator -PasswordNeverExpires $true
-Set-LocalUser -Name $BUILD_USERNAME -PasswordNeverExpires $true
+if ($user = Get-LocalUser -Name $BUILD_USERNAME -ErrorAction SilentlyContinue) {
+    Write-Output "Disabling password expiration for the local Administrator accounts..."
+    Set-LocalUser -Name $localAdministrator -PasswordNeverExpires $true
+    Set-LocalUser -Name $BUILD_USERNAME -PasswordNeverExpires $true
+} else {
+    Write-Output "User $BUILD_USERNAME does not exist."
+}
 
 # Enable Remote Desktop.
 Write-Output "Enabling Remote Desktop..."
-Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" -Name "fDenyTSConnections" -Value 0 | Out-Null
-Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 0
-Enable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'
+$rdpOptions = @{
+    "fDenyTSConnections" = 0
+    "UserAuthentication" = 0
+}
+foreach ($option in $rdpOptions.GetEnumerator()) {
+    try {
+        Set-RegistryValue -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" -Name $option.Name -Value $option.Value
+    } catch {
+        Write-Output "Failed to set Remote Desktop option $option.Name: $_"
+    }
+}
+try {
+    Enable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'
+    Write-Output "Remote Desktop enabled successfully."
+} catch {
+    Write-Output "Failed to enable Remote Desktop firewall rule: $_"
+}

--- a/scripts/windows/windows-reset.ps1
+++ b/scripts/windows/windows-reset.ps1
@@ -1,0 +1,90 @@
+# Copyright 2023 VMware, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2
+
+<#
+    .DESCRIPTION
+    Windows Remote Management configuration reset for Windows Desktop.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$firewallGroupName = 'Windows Remote Management'
+$httpFirewallRuleDisplayName = 'Windows Remote Management (HTTP-In)'
+$httpsFirewallRuleName = 'WINRM-HTTPS-In-TCP'
+$httpsFirewallRuleDisplayName = 'Windows Remote Management (HTTPS-In)'
+$protocol = 'TCP'
+$transport = 'HTTPS'
+
+$logDirectory = 'C:\Packer'
+$logFile = 'C:\windows-winrm-reset.log'
+
+# Start the logging for the Windows Remote Management reset.
+Start-Transcript -Path $logFile -Force
+Write-Output 'Starting the logging for the Windows Remote Management reset...'
+
+# Start the Windows Remote Management configuration reset.
+Write-Output 'Starting the Windows Remote Management reset...'
+
+# Get the operating system information.
+Write-Output 'Getting the operating system information...'
+$osType = (Get-CimInstance -ClassName Win32_OperatingSystem).InstallationType.ToLower()
+Write-Output "Operating system type: $osType"
+
+# Check if Windows Remote Management service is running.
+$service = Get-Service -Name WinRM -ErrorAction SilentlyContinue
+
+if ($null -eq $service) {
+    Write-Output "Windows Remote Management service does not exist."
+    exit 1
+} elseif ($service.Status -ne 'Running') {
+    Write-Output "Windows Remote Management service is not running, starting it now..."
+    try {
+        Start-Service -Name WinRM -ErrorAction Stop
+    } catch {
+        Write-Output "Failed to start WinRM service: $_"
+        exit 1
+    }
+}
+
+# Reset the Windows Remote Management configuration to the default settings if the operating system is a client.
+if ($osType -eq 'client') {
+    Write-Output 'Resetting the Windows Remote Management configuration to the default settings...'
+    try {
+        Disable-PSRemoting -Force
+        Get-ChildItem WSMan:\localhost\Listener | Where-Object { $_.Keys -contains "Transport=$transport" } | Remove-Item -Recurse -Confirm:$false
+        Get-NetFirewallRule -DisplayName $httpFirewallRuleDisplayName | Remove-NetFirewallRule -Confirm:$false
+        Get-NetFirewallRule -Name $httpsFirewallRuleName | Remove-NetFirewallRule -Confirm:$false
+    } catch {
+        Write-Output "Failed to reset Windows Remote Management configuration: $_"
+        exit 1
+    }
+}
+
+# Stop the Windows Remote Management configuration reset logging.
+Write-Output 'Stopping the Windows Remote Management configuration reset logging...'
+Stop-Transcript
+
+# Save the Windows Remote Management configuration reset log.
+Write-Output 'Saving the Windows Remote Management configuration reset log...'
+try {
+    New-Item -Path $logDirectory -Type Directory -Force | Out-Null
+    $acl = Get-Acl $logDirectory
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule('Administrators', 'FullControl', 'ContainerInherit,Objectinherit', 'none', 'Allow')
+    $acl.AddAccessRule($rule)
+    Set-Acl -Path $logDirectory -AclObject $acl
+} catch {
+    Write-Output "Failed to set ACL for '$logDirectory': $_"
+    exit 1
+}
+
+# Move the Windows Remote Management configuration reset log.
+Write-Output 'Moving the Windows Remote Management configuration reset log...'
+try {
+    Move-Item -Path $logFile -Destination $logDirectory -Force -ErrorAction Stop
+} catch {
+    Write-Output "Failed to move log file: $_"
+    exit 1
+}
+
+# Windows Remote Management configuration reset completed.
+Write-Output 'Windows Remote Management configuration reset completed.'

--- a/scripts/windows/windows-shutdown.ps1
+++ b/scripts/windows/windows-shutdown.ps1
@@ -1,0 +1,61 @@
+# Copyright 2023 VMware, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2
+
+<#
+    .DESCRIPTION
+    Disables Windows Remote Management on Windows builds.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$httpFirewallRuleDisplayName = 'Windows Remote Management (HTTP-In)'
+
+# Disable PowerShell Remoting.
+Write-Output 'Disabling PowerShell Remoting...'
+try {
+    Disable-PSRemoting -Force -Confirm:$false
+
+    # Add a check to ensure that PowerShell Remoting is disabled.
+    if ((Get-PSSessionConfiguration -Name Microsoft.PowerShell -ErrorAction SilentlyContinue).Enabled) {
+        throw 'Failed to disable PowerShell Remoting.'
+    }
+} catch {
+    Write-Output "Failed to disable PowerShell Remoting: $_"
+    exit 1
+}
+
+# Disable Windows Remote Management service.
+Write-Output 'Disabling Windows Remote Management service...'
+try {
+    Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+    Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\policies\system -Name LocalAccountTokenFilterPolicy -Value 0
+    Stop-Service -Name WinRM
+    Set-Service -Name WinRM -StartupType Disabled
+    $count = 0
+    while ((Get-Service -Name WinRM).Status -ne 'Stopped' -and $count -lt 10) {
+        Start-Sleep -Seconds 2
+        $count++
+    }
+    if ((Get-Service -Name WinRM).Status -ne 'Stopped') {
+        throw 'Failed to stop WinRM service within the expected time.'
+    }
+} catch {
+    Write-Output "Failed to disable Windows Remote Management service: $_"
+    exit 1
+}
+
+# Block Windows Remote Management in the Windows Firewall.
+Write-Output 'Blocking Windows Remote Management in the Windows Firewall...'
+try {
+    if (Get-NetFirewallRule -DisplayName $httpFirewallRuleDisplayName -ErrorAction SilentlyContinue) {
+        Set-NetFirewallRule -DisplayName $httpFirewallRuleDisplayName -Enabled False -PassThru
+    } else {
+        Write-Output "Firewall rule '$httpFirewallRuleDisplayName' does not exist."
+    }
+} catch {
+    Write-Output "Failed to disable firewall rule: $_"
+    exit 1
+}
+
+# Shutdown the machine.
+shutdown /s /t 10 /f /d p:4:1 /c \"Shutdown by Packer\"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

### UPDATES

- Enhances the `./windows-init.ps1` script to configure WinRM based on the operating system type - `Client` vs `Server` / `Server Core` - and log the configuration.
- Windows Server builds will configure WinRM for HTTPS (`TCP 5989`) listener **only**; Windows Desktop builds will continue to WinRM over HTTP (`TCP 5985`) listener, the default.
- Reset Windows Desktop builds to the operating system default setting (disabled) for WinRM upon build completion.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Resolves #265

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
