### PR TITLE
chore(deps): bump windows 10 to 22h2 to latest

### DIFF
--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -38,9 +38,9 @@ vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_10_business_editions_version_22h2_updated_nov_2022_x64_dvd_e8577df7.iso"
+iso_file           = "en-us_windows_10_business_editions_version_22h2_updated_dec_2022_x64_dvd_3f239c01.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "BA1C32F0BDA69022A4843F05C91B90DB8DCA6EC13123D1CF7C8160828128BD64"
+iso_checksum_value = "C49D43C42D4124EF5CBAD36DC48A9664DB26F003737F8DF5A4D56C7389BB6D70"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Windows 10 to the 22H2 December 2022 release.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>



## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
