### PR TITLE
fix: windows 11 guest customization failure

### DIFF
--- a/scripts/windows/windows-prepare.ps1
+++ b/scripts/windows/windows-prepare.ps1
@@ -69,3 +69,13 @@ Write-Output "Enabling Remote Desktop..."
 Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" -Name "fDenyTSConnections" -Value 0 | Out-Null
 Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 0
 Enable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'
+
+# Check if the OS is Windows 11
+if ((Get-ComputerInfo | Select-Object -expand OsName) -match 11) {
+    # Remove Appx Packages causing Sysprep to fail - https://kb.vmware.com/s/article/82532
+    Write-Output "Removing Appx Packages causing Sysprep to fail..."
+    Write-Output "Setting the Non-Removable App Policy for TikTok..."
+    Set-NonRemovableAppsPolicy -Online -PackageFamilyName "BytedancePte.Ltd.TikTok_1.0.5.0_neutral__6yccndn6064se" -NonRemovable 0
+    Write-Output "Removing Appx Package for TikTok for all users..."
+    Remove-AppxPackage -AllUsers -Package "BytedancePte.Ltd.TikTok_1.0.5.0_neutral__6yccndn6064se"
+}


### PR DESCRIPTION
<!--
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.
-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

At present, when using a Packer built Windows 11 image, the guest customization step fails when deploying with Terraform.

Sysprep is failing with the following:

```console
2023-01-06 23:35:44, Error                 SYSPRP Package BytedancePte.Ltd.TikTok_1.0.5.0_neutral__6yccndn6064se was installed for a user, but not provisioned for all users. This package will not function properly in the sysprep image.
2023-01-06 23:35:44, Error                 SYSPRP Failed to remove apps for the current user: 0x80073cf2.
2023-01-06 23:35:44, Error                 SYSPRP Exit code of RemoveAllApps thread was 0x3cf2.
2023-01-06 23:35:44, Error                 SYSPRP ActionPlatform::LaunchModule: Failure occurred while executing 'SysprepGeneralizeValidate' from C:\Windows\System32\AppxSysprep.dll; dwRet = 0x3cf2
2023-01-06 23:35:44, Error                 SYSPRP SysprepSession::Validate: Error in validating actions from C:\Windows\System32\Sysprep\ActionFiles\Generalize.xml; dwRet = 0x3cf2
2023-01-06 23:35:44, Error                 SYSPRP RunPlatformActions:Failed while validating Sysprep session actions; dwRet = 0x3cf2
2023-01-06 23:35:44, Error      [0x0f0070] SYSPRP RunDlls:An error occurred while running registry sysprep DLLs, halting sysprep execution. dwRet = 0x3cf2
2023-01-06 23:35:44, Error      [0x0f00d8] SYSPRP WinMain:Hit failure while pre-validate sysprep generalize internal providers; hr = 0x80073cf2
```

Troubleshooting me led this to KB from VMware
https://kb.vmware.com/s/article/82532

To overcome this, I had to remove the AppX Package 'BytedancePte.Ltd.TikTok_1.0.5.0_neutral__6yccndn6064se' as part of the Packer build

<!--
    Please provide a clear and concise description of the pull request.
-->

This pull request looks to remove the AppXPackage 'BytedancePte.Ltd.TikTok_1.0.5.0_neutral__6yccndn6064se' as part of the Packer build

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - #1234
-->

Resolves #468

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
