### PR TITLE
feat: update .gitignore terraform/artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,19 +19,24 @@ crash.log
 # HashiCorp Terraform
 ## Ignore .terraform directories.
 **/.terraform/*
+## Ignore dependency lock files.
 .terraform.lock.hcl
 ## Ignore .tfstate files
 *.tfstate
 *.tfstate.*
 ## Ignore crash.log files.
 crash.log
+crash.*.log
 ## Ignore .tfvars files.
 *.tfvars
+*.tfvars.json
 ## Ignore override files.
 override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+## Ignore tfplan files.
+*tfplan*
 ## Ignore configuration files.
 .terraformrc
 terraform.rc
@@ -42,10 +47,10 @@ config/
 
 # Artifacts
 ## Ignore artifacts directory.
-artifacts/*.mf
-artifacts/*.nvram
-artifacts/*.ovf
-artifacts/*.vmdk
+artifacts/**/*.mf
+artifacts/**/*.nvram
+artifacts/**/*.ovf
+artifacts/**/*.vmdk
 
 # Manifests
 ## Ignore manifests directory.


### PR DESCRIPTION
## Summary of Pull Request

1. Updated .gitignore to correctly ignore  `.vmdk`, `.nvram`, `.ovf` and `.mf` files.
2. Added `tfplan` files to .gitignore, also added additional ignores here to match the [GitHub template](https://github.com/github/gitignore/blob/main/Terraform.gitignore).

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.

## Related to Existing Issues

Resolves #472

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.