### PR TITLE
chore(deps): bump hashcorp/vsphere from v2.2.0 to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 :sweat_drops: **Chore**:
 - Updates `required_versions` for `packer` to `>= 1.8.6`. [GH-486](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/486)
-- Updates `required_plugins` for `packer-plugin-git` to `>= 0.3.3`. [GH-487](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/487)
+- Updates `required_plugins` for `ethanmdavidson/packer-plugin-git` to `>= 0.3.3`. [GH-487](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/487)
+- Updates `required_versions` for `hashicorp/vsphere` to `>= 2.3.1`.[GH-488](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/488)
 
 ## [v23.01](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v23.01)
 

--- a/terraform/vsphere-role/versions.tf
+++ b/terraform/vsphere-role/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-cloud-init/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-linux-guest-customization/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-ovf-windows-guest-customization/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-template-linux-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-template-linux-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/content-library-template-windows-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/content-library-template-windows-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-linux-cloud-init-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-cloud-init-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-linux-cloud-init/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-cloud-init/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-linux-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-linux-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-linux-guest-customization/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-windows-guest-customization-hcp-packer/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-windows-guest-customization-hcp-packer/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"

--- a/terraform/vsphere-virtual-machine/template-windows-guest-customization/versions.tf
+++ b/terraform/vsphere-virtual-machine/template-windows-guest-customization/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.2.0"
+      version = ">= 2.3.1"
     }
   }
   required_version = ">= 1.3.7"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Terraform Provider for VMware vSphere (`hashicorp/vsphere`) from v2.2.0 to v2.3.1.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
