### PR TITLE
chore(deps): bump debian from v11.6 to v11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Updates Almalinux 8 to 8.8 release. [GH-570](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/570)
 - Updates Rocky Linux 9 to 9.2 release. [GH-571](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/571)
 - Updates Rocky Linux 8 to 8.8 release. [GH-572](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/572)
+- Updates Debian 11 to 11.7 release. [GH-574](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/574)
 
 ## [v23.01](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v23.01)
 

--- a/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
+++ b/builds/linux/debian/11/linux-debian.auto.pkrvars.hcl
@@ -9,7 +9,7 @@ vm_guest_os_keyboard = "us"
 vm_guest_os_timezone = "UTC"
 vm_guest_os_family   = "linux"
 vm_guest_os_name     = "debian"
-vm_guest_os_version  = "11.6"
+vm_guest_os_version  = "11.7"
 
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "other5xLinux64Guest"
@@ -29,9 +29,9 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path           = "iso/linux/debian"
-iso_file           = "debian-11.6.0-amd64-netinst.iso"
+iso_file           = "debian-11.7.0-amd64-netinst.iso"
 iso_checksum_type  = "sha512"
-iso_checksum_value = "224cd98011b9184e49f858a46096c6ff4894adff8945ce89b194541afdfd93b73b4666b0705234bd4dff42c0a914fdb6037dd0982efb5813e8a553d8e92e6f51"
+iso_checksum_value = "4460ef6470f6d8ae193c268e213d33a6a5a0da90c2d30c1024784faa4e4473f0c9b546a41e2d34c43fbbd43542ae4fb93cfd5cb6ac9b88a476f1a6877c478674"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Bumps Debian 11 from v11.6 to v11.7.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
