### PR TITLE
fix(deps): bump windows 11 22h2 to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Updates CentOS Stream 9 to latest June 2023 release. [GH-567](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/567)
 - Updates CentOS Stream 8 to latest June 2023 release. [GH-568](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/568)
 - Updates Windows Server 2022 to May 2023 (US English) release. [GH-579](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/579)
-- Updates Windows 11 22H2 to May 2023 (US English) release. [GH-580](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/580)
+- Updates Windows 11 22H2 to May 2023 (US English) release. [GH-580](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/580), [GH-583](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/583)
 - Updates Windows 10 22H2 to May 2023 (US English) release. [GH-581](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/581)
 
 ## [v23.01](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v23.01)

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -39,9 +39,9 @@ vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path           = "iso/windows/desktop"
-iso_file           = "en-us_windows_11_business_editions_version_21h2_updated_may_2023_x64_dvd_83da6dba.iso"
+iso_file           = "en-us_windows_11_business_editions_version_22h2_updated_may_2023_x64_dvd_c2d14816.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "5411B045A21C5237AB7911F2CDCDA6E3D160C6DE30C8FAFED5E2A64629E9E379"
+iso_checksum_value = "43B00287A1FCC0F31C9E85CF7AB421887C0B23887AD7DE5F790D17F5B8AE33DE"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Windows 11 22H2 to the May 2023 (US English) release.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
