### PR TITLE
refactor: remove chocolatey from windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,11 @@
 - Updates CentOS Stream 8 to latest June 2023 release. [GH-568](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/568)
 - Updates Windows Server 2022 to May 2023 (US English) release. [GH-579](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/579)
 - Updates Windows 11 22H2 to May 2023 (US English) release. [GH-580](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/580), [GH-583](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/583)
-- Updates Windows 10 22H2 to May 2023 (US English) release. [GH-581](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/581)
+- Updates Windows 10 22H2 to May 2023 (US English) release. [GH-575](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/581)
+
+:wrench: **Refactor**:
+
+- Removes the installation of Chocolatey from the Microsoft Windows guest operating system builds. [GH-586](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/586)
 
 ## [v23.01](https://github.com/vmware-samples/packer-examples-for-vsphere/releases/tag/v23.01)
 

--- a/builds/windows/desktop/10/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/10/windows.auto.pkrvars.hcl
@@ -55,7 +55,5 @@ communicator_timeout = "12h"
 // Provisioner Settings
 scripts = ["scripts/windows/windows-prepare.ps1"]
 inline = [
-  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
-  "choco feature enable -n allowGlobalConfirmation",
   "Get-EventLog -LogName * | ForEach { Clear-EventLog -LogName $_.Log }"
 ]

--- a/builds/windows/desktop/11/windows.auto.pkrvars.hcl
+++ b/builds/windows/desktop/11/windows.auto.pkrvars.hcl
@@ -56,7 +56,5 @@ communicator_timeout = "12h"
 // Provisioner Settings
 scripts = ["scripts/windows/windows-prepare.ps1"]
 inline = [
-  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
-  "choco feature enable -n allowGlobalConfirmation",
   "Get-EventLog -LogName * | ForEach { Clear-EventLog -LogName $_.Log }"
 ]

--- a/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2019/windows-server.auto.pkrvars.hcl
@@ -60,7 +60,5 @@ communicator_timeout = "12h"
 // Provisioner Settings
 scripts = ["scripts/windows/windows-prepare.ps1"]
 inline = [
-  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
-  "choco feature enable -n allowGlobalConfirmation",
   "Get-EventLog -LogName * | ForEach { Clear-EventLog -LogName $_.Log }"
 ]

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -60,7 +60,5 @@ communicator_timeout = "12h"
 // Provisioner Settings
 scripts = ["scripts/windows/windows-prepare.ps1"]
 inline = [
-  "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
-  "choco feature enable -n allowGlobalConfirmation",
   "Get-EventLog -LogName * | ForEach { Clear-EventLog -LogName $_.Log }"
 ]


### PR DESCRIPTION


<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Removes the installation of Chocolatey from the Microsoft Windows guest operating system builds. .Net 4.8 is required before installation. This can be managed by the user instead of this project.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [x] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #585

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
