### PR TITLE
feat: add templated `.gitlab-ci.yml` method

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,225 @@
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+##############################################################################
+##
+## Auto-generated .gitlab-ci.yml for building Packer Example for vSphere
+##
+## Do not modify this file directly, either:
+##
+##     - modify the source build.yaml
+##     - modify the template build-ci.tmpl
+##
+## then run the following command to re-create the .gitlab-ci.yml file:
+##
+##     gomplate -c build.yaml -f build-ci.tmpl -o .gitlab-ci.yml
+##
+##############################################################################
+
+variables:
+    SCRIPT_PATH: "${CI_PROJECT_DIR}"
+    CONFIG_PATH: "${CI_PROJECT_DIR}/config"
+    INPUT_PATH: ""
+    EXTRA_VAR_FILES: ""
+    BUILD_ONLY: ""
+
+##############################################################################
+
+.packer-build:
+    stage: build
+    #tags: 
+    #    - packer
+    before_script:
+        - "packer init \"$INPUT_PATH\""
+        - "packer validate \"$INPUT_PATH\""
+    script:
+        - "packer build -force -on-error=ask -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} ${BUILD_ONLY} \"$INPUT_PATH\""
+    when: manual
+
+##############################################################################
+
+VMware-Photon-OS-5:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/photon/5/"
+
+##############################################################################
+
+VMware-Photon-OS-4:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/photon/4/"
+
+##############################################################################
+
+Debian-12:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/debian/12/"
+
+##############################################################################
+
+Debian-11:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/debian/11/"
+
+##############################################################################
+
+Ubuntu-Server-22.04-LTS:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/ubuntu/22-04-lts/"
+
+##############################################################################
+
+Ubuntu-Server-20.04-LTS:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/ubuntu/20-04-lts/"
+
+##############################################################################
+
+Red-Hat-Enterprise-Linux-9:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/rhel/9/"
+        EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/rhsm.pkrvars.hcl"
+
+##############################################################################
+
+Red-Hat-Enterprise-Linux-8:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/rhel/8/"
+        EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/rhsm.pkrvars.hcl"
+
+##############################################################################
+
+Red-Hat-Enterprise-Linux-7:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/rhel/7/"
+        EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/rhsm.pkrvars.hcl"
+
+##############################################################################
+
+AlmaLinux-OS-9:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/almalinux/9/"
+
+##############################################################################
+
+AlmaLinux-OS-8:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/almalinux/8/"
+
+##############################################################################
+
+Rocky-Linux-9:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/rocky/9/"
+
+##############################################################################
+
+Rocky-Linux-8:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/rocky/8/"
+
+##############################################################################
+
+CentOS-Stream-9:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/centos/9-stream/"
+
+##############################################################################
+
+CentOS-Stream-8:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/centos/8-stream/"
+
+##############################################################################
+
+CentOS-Linux-7:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/centos/7/"
+
+##############################################################################
+
+SUSE-Linux-Enterprise-Server-15:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/sles/15/"
+        EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/scc.pkrvars.hcl"
+
+##############################################################################
+
+Windows-Server-2022-All:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2022/"
+
+##############################################################################
+
+Windows-Server-2022-Standard-Only:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2022/"
+        BUILD_ONLY: "--only vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core"
+
+##############################################################################
+
+Windows-Server-2022-Datacenter-Only:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2022/"
+        BUILD_ONLY: "--only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core"
+
+##############################################################################
+
+Windows-Server-2019-All:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2019/"
+
+##############################################################################
+
+Windows-Server-2019-Standard-Only:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2019/"
+        BUILD_ONLY: "--only vsphere-iso.windows-server-standard-dexp,vsphere-iso.windows-server-standard-core"
+
+##############################################################################
+
+Windows-Server-2019-Datacenter-Only:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/server/2019/"
+        BUILD_ONLY: "--only vsphere-iso.windows-server-datacenter-dexp,vsphere-iso.windows-server-datacenter-core"
+
+##############################################################################
+
+Windows-11:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/desktop/11/"
+
+##############################################################################
+
+Windows-10:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/windows/desktop/10/"
+
+##############################################################################
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Adds VMware Photon OS 5.0 to the project. [GH-582](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/582)
 - Adds Debian 12 to the project. [GH-584](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/584)
+- Adds an example `.gitlab.yml` file for GitLab CI/CD. [GH-675](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/675)
+- Adds a `build-ci.tmpl` that can be used to create or update the `.gitlab-ci.yml` file using gomplate. [GH-675](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/675)
 
 :bug: **Bugfix**:
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The directory structure of the repository.
 ```console
 ├── build.sh
 ├── build.tmpl
+├── build-ci.tmpl
 ├── build.yaml
 ├── CHANGELOG.md
 ├── CODE_OF_CONDUCT.md
@@ -992,6 +993,16 @@ Generate a custom build script:
 
 ```console
 rainpole@macos> gomplate -c build.yaml -f build.tmpl -o build.sh
+```
+
+### Generate a Custom GitLab CI/CD pipeline
+
+The GitLab CI/CD YAML (`.gitlab-ci.yml`) can be generated using a template (`./build-ci.tmpl`) and a configuration file in YAML (`./build.yaml`).
+
+Generate a custom `.gitlab-ci.yml`:
+
+```console
+rainpole@macos> gomplate -c build.yaml -f build-ci.tmpl -o .gitlab-ci.yml
 ```
 
 Happy building!!!

--- a/build-ci.tmpl
+++ b/build-ci.tmpl
@@ -1,0 +1,60 @@
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+##############################################################################
+##
+## Auto-generated .gitlab-ci.yml for building Packer Example for vSphere
+##
+## Do not modify this file directly, either:
+##
+##     - modify the source build.yaml
+##     - modify the template build-ci.tmpl
+##
+## then run the following command to re-create the .gitlab-ci.yml file:
+##
+##     gomplate -c build.yaml -f build-ci.tmpl -o .gitlab-ci.yml
+##
+##############################################################################
+
+variables:
+    SCRIPT_PATH: "${CI_PROJECT_DIR}"
+    CONFIG_PATH: "${CI_PROJECT_DIR}/config"
+    INPUT_PATH: ""
+    EXTRA_VAR_FILES: ""
+    BUILD_ONLY: ""
+
+##############################################################################
+
+.packer-build:
+    stage: build
+    #tags: 
+    #    - packer
+    before_script:
+        - "packer init \"$INPUT_PATH\""
+        - "packer validate \"$INPUT_PATH\""
+    script:
+        - "packer build -force -on-error=ask -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} ${BUILD_ONLY} \"$INPUT_PATH\""
+    when: manual
+
+##############################################################################
+
+{{ range $menu := (ds "build").menu -}}
+{{ range $submenu := $menu.submenu -}}
+
+{{ $submenu.entry | strings.ReplaceAll " (cloud-init)" "" | strings.ReplaceAll " " "-" | strings.ReplaceAll "---" "-" }}:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/{{ $submenu.build.path }}"
+{{- if (coll.Has $submenu.build "only") }}
+        BUILD_ONLY: "--only {{ join $submenu.build.only "," }}"
+{{- end -}}
+{{- if (coll.Has $submenu.build "var_files") -}}
+{{ range $submenu.build.var_files }}
+        EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/{{ . }}"
+{{- end -}}{{- end }}
+
+##############################################################################
+
+{{ end }}{{ end -}}


### PR DESCRIPTION
## Summary of Pull Request

Add templated way of generating a `.gitlab-ci.yml` file to enable a GitLab CI/CD pipeline to build the Packer templates

This change:

- Adds new `build-ci.tmpl` that can be used to crete/update `.gitlab-ci.yml` file
- Adds example `.gitlab.yml` file.
- Adds section to `README.md` describing how to use `build-ci.tmpl` that can be used to create/update `.gitlab-ci.yml` file.

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [X] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes #674 

## Test and Documentation Coverage

- [X] Tests have been completed in private GitLab instance
- [X] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
