### PR TITLE
fix: debian 12 mount of  `/dev/sr1` with  `http` data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 :bug: **Bugfix**:
 
 - Updates Debian 11 to include `build_password` in the `linux-debian.pkr.hcl` configuration file. [GH-653](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/653)
+- Updates Debian 12 to ensure `/dev/sr1` is not mounted with use of the default `http` data source. No changes to the `disk` data source. [GH-685](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/685)
 
 :sweat_drops: **Chore**:
 

--- a/builds/linux/debian/12/linux-debian.pkr.hcl
+++ b/builds/linux/debian/12/linux-debian.pkr.hcl
@@ -52,6 +52,8 @@ locals {
     })
   }
   data_source_command = var.common_data_source == "http" ? "url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "file=/media/ks.cfg"
+  mount_cdrom_command = "<leftAltOn><f2><leftAltOff> <enter><wait> mount /dev/sr1 /media<enter> <leftAltOn><f1><leftAltOff>"
+  mount_cdrom         = var.common_data_source == "http" ? " " : local.mount_cdrom_command
   vm_name             = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
   bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
   bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
@@ -122,10 +124,7 @@ source "vsphere-iso" "linux-debian" {
     "<wait30s>",
     "<enter><wait>",
     "<enter><wait>",
-    "<leftAltOn><f2><leftAltOff>",
-    "<enter><wait>",
-    "mount /dev/sr1 /media<enter>",
-    "<leftAltOn><f1><leftAltOff>",
+    " ${local.mount_cdrom}",
     "<down><down><down><down><enter>"
   ]
   ip_wait_timeout  = var.common_ip_wait_timeout


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Fix Debian 12 mount of  `/dev/sr1` with  `http` data source.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #673

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->