### PR TITLE
Fix for issue #701

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
     #    - packer
     before_script:
         - "packer init \"$INPUT_PATH\""
-        - "packer validate \"$INPUT_PATH\""
+        - "packer validate -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} \"$INPUT_PATH\""
     script:
         - "packer build -force -on-error=ask -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} ${BUILD_ONLY} \"$INPUT_PATH\""
     when: manual
@@ -160,6 +160,20 @@ SUSE-Linux-Enterprise-Server-15:
     variables:
         INPUT_PATH: "$SCRIPT_PATH/builds/linux/sles/15/"
         EXTRA_VAR_FILES: " -var-file=$CONFIG_PATH/scc.pkrvars.hcl"
+
+##############################################################################
+
+Oracle-Enterprise-Linux-9:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/oracle/9/"
+
+##############################################################################
+
+Oracle-Enterprise-Linux-8:
+    extends: .packer-build
+    variables:
+        INPUT_PATH: "$SCRIPT_PATH/builds/linux/oracle/8/"
 
 ##############################################################################
 

--- a/build-ci.tmpl
+++ b/build-ci.tmpl
@@ -33,7 +33,7 @@ variables:
     #    - packer
     before_script:
         - "packer init \"$INPUT_PATH\""
-        - "packer validate \"$INPUT_PATH\""
+        - "packer validate -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} \"$INPUT_PATH\""
     script:
         - "packer build -force -on-error=ask -var-file=\"$CONFIG_PATH/vsphere.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/build.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/ansible.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/proxy.pkrvars.hcl\" -var-file=\"$CONFIG_PATH/common.pkrvars.hcl\" ${EXTRA_VAR_FILES} ${BUILD_ONLY} \"$INPUT_PATH\""
     when: manual


### PR DESCRIPTION
## Summary of Pull Request

The packer validate step in the new `.gitlab-ci.yml` does not include references to the necessary `.pkrvar.hcl` files and that breaks the GitLab CI/CD pipeline.

This PR add the reference to the necessary `.pkrvar.hcl` files.

## Type of Pull Request

- [X] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

- Resolves #701 

Issue Number: #701 

## Test and Documentation Coverage

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
