### PR TITLE
chore(deps): bump windows server 2022 to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,9 @@
 - Updates CentOS Stream 9 to latest June 2023 release. [GH-567](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/567)
 - Updates CentOS Stream 8 to latest June 2023 release. [GH-568](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/568)
 - Updates SLES 15 to 15.5 release. [GH-740](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/740)
-- Updates Windows Server 2022 to May 2023 (US English) release. [GH-579](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/579)
-- Updates Windows 11 22H2 to May 2023 (US English) release. [GH-580](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/580), [GH-583](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/583)
-- Updates Windows 10 22H2 to May 2023 (US English) release. [GH-575](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/581)
+- Updates Windows Server 2022 to October 2023 (US English) release. [GH-744](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/744)
+- Updates Windows 11 22H2 to October 2023 (US English) release. [GH-743](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/743)
+- Updates Windows 10 22H2 to October 2023 (US English) release. [GH-742](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/742)
 
 :wrench: **Refactor**:
 

--- a/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
+++ b/builds/windows/server/2022/windows-server.auto.pkrvars.hcl
@@ -47,7 +47,7 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path = "iso/windows/server"
-iso_file = "en-us_windows_server_2022_updated_may_2023_x64_dvd_7eb3ad7c.iso"
+iso_file = "en-us_windows_server_2022_updated_oct_2023_x64_dvd_63dab61a.iso"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Windows Server 2022 to the October 2023 (US English) release.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
