### PR TITLE
Fix issue-778

### DIFF
--- a/builds/linux/ubuntu/23-10/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/23-10/linux-ubuntu.pkr.hcl
@@ -184,9 +184,11 @@ build {
   sources = ["source.vsphere-iso.linux-ubuntu"]
 
   provisioner "ansible" {
-    user          = var.build_username
-    playbook_file = "${path.cwd}/ansible/main.yml"
-    roles_path    = "${path.cwd}/ansible/roles"
+    user                   = var.build_username
+    galaxy_file            = "${path.cwd}/ansible/requirements.yml"
+    galaxy_force_with_deps = true
+    playbook_file          = "${path.cwd}/ansible/main.yml"
+    roles_path             = "${path.cwd}/ansible/roles"
     ansible_env_vars = [
       "ANSIBLE_CONFIG=${path.cwd}/ansible/ansible.cfg"
     ]


### PR DESCRIPTION
Re-add missing galaxy_file and galaxy_froce_with_deps entries from Ubuntu Server 23.10 linux-ubuntu.pkr.hcl file.

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Ubuntu Server 23.10 failing due ansible collection(s) missing

For some reason, the Ubuntu 23.10 `linux-ubuntu.pkr.hcl` file was missing `galaxy_file` and `galaxy_force_with_deps` from the ansible provisioner section.

## Type of Pull Request

- [X] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Resolves #778 

Issue Number: #778 

## Test and Documentation Coverage

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
