### PR TITLE
modify check to regenerate SSH keys

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -49,5 +49,5 @@
   lineinfile:
     dest: /etc/rc.local
     create: true
-    line: "#!/bin/bash\ntest -f /etc/ssh/ssh_host_dsa_key || dpkg-reconfigure openssh-server\nexit 0\n"
+    line: "#!/bin/bash\nif test -z \"$(find /etc/ssh/ -iname 'ssh_host_*_key*')\"; then\n    dpkg-reconfigure openssh-server\nfi\nexit 0\n"
     mode: '0755'


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

ansible task for generate ssh keys test if dsa keys exist but dsa are deprecated since openssh 7.0

On OpenSSH Legacy Options (http://www.openssh.com/legacy.html) : 
"OpenSSH 7.0 and greater similarly disable the ssh-dss (DSA) public key algorithm. It too is weak and we recommend against its use."

Instead of testing if dsa keys exist, we test if any key files exist, regardless of the algorithm.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
