### PR TITLE
fix: enhance check to regenerate SSH keys

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -46,8 +46,12 @@
 
 # Tasks for setting SSH keys to regenerate.
 - name: "Setting SSH keys to regenerate."
-  lineinfile:
+  copy:
     dest: /etc/rc.local
-    create: true
-    line: "#!/bin/bash\ntest -f /etc/ssh/ssh_host_dsa_key || dpkg-reconfigure openssh-server\nexit 0\n"
-    mode: '0755'
+    content: |
+      #!/bin/bash
+      if test -z "$(find /etc/ssh/ -iname 'ssh_host_*_key*')"; then
+          dpkg-reconfigure openssh-server
+      fi
+      exit 0
+    mode: 0755


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Enhances the Ansible task to use `copy` versus `lineinfile` to create `/etc/rc.local` with a check for all SSH host keys.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #793

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
