### PR TITLE
chore: Update Windows 10/11, Windows Server 2022, and Debian 12 ISOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Adds templates with unit tests for managing custom network and storage configurations for Linux Distributions. [GH-473](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/473), [GH-805](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/805)
 - Adds additional configuration to install packages for Linux Distributions. [GH-800](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/800)
 
+:sweat_drops: **Chore**:
+
+- Updates Debian 12 to 12.4 release. [GH-816](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/816)
+- Updates Windows 10 22H2 to January 2024 (US English) release. [GH-816](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/816)
+- Updates Windows 11 22H2 to January 2024 (US English) release. [GH-816](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/816)
+- Updates Windows Server 2022 to January 2024 (US English) release. [GH-816](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/816)
+
 ## v23.11
 
 > Release Date: 2023-11-28

--- a/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
@@ -12,7 +12,7 @@ vm_guest_os_keyboard = "us"
 vm_guest_os_timezone = "UTC"
 vm_guest_os_family   = "linux"
 vm_guest_os_name     = "debian"
-vm_guest_os_version  = "12.2"
+vm_guest_os_version  = "12.4"
 
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "other5xLinux64Guest"
@@ -32,7 +32,7 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path = "iso/linux/debian"
-iso_file = "debian-12.2.0-amd64-netinst.iso"
+iso_file = "debian-12.4.0-amd64-netinst.iso"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/builds/windows/desktop/10/windows.pkrvars.hcl.example
+++ b/builds/windows/desktop/10/windows.pkrvars.hcl.example
@@ -45,7 +45,7 @@ vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path = "iso/windows/desktop"
-iso_file = "en-us_windows_10_business_editions_version_22h2_updated_oct_2023_x64_dvd_8fac2c2d.iso"
+iso_file = "en-us_windows_10_business_editions_version_22h2_updated_jan_2024_x64_dvd_5453cae4.iso"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/desktop/11/windows.pkrvars.hcl.example
+++ b/builds/windows/desktop/11/windows.pkrvars.hcl.example
@@ -46,7 +46,7 @@ vm_video_displays        = 1
 
 // Removable Media Settings
 iso_path = "iso/windows/desktop"
-iso_file = "en-us_windows_11_business_editions_version_22h2_updated_oct_2023_x64_dvd_e6b6f11c.iso"
+iso_file = "en-us_windows_11_business_editions_version_23h2_updated_jan_2024_x64_dvd_12855bc9.iso"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"

--- a/builds/windows/server/2022/windows-server.pkrvars.hcl.example
+++ b/builds/windows/server/2022/windows-server.pkrvars.hcl.example
@@ -47,7 +47,7 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path = "iso/windows/server"
-iso_file = "en-us_windows_server_2022_updated_oct_2023_x64_dvd_63dab61a.iso"
+iso_file = "en-us_windows_server_2022_updated_jan_2024_x64_dvd_2b7a0c9f.iso"
 
 // Boot Settings
 vm_boot_order       = "disk,cdrom"


### PR DESCRIPTION
chore: Update Windows 10/11, Windows Server 2022, and Debian 12 ISOs to latest

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Updates `.pkrvars.hcl.example` files to latest ISOs for:
- Windows 10
- Windows 11
- Windows Server 2022
- Debian 12

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [X] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
