### PR TITLE
fix: debian boot delay

### DIFF
--- a/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/11/linux-debian.pkrvars.hcl.example
@@ -35,7 +35,7 @@ iso_path = "iso/linux/debian"
 iso_file = "debian-11.8.0-amd64-netinst.iso"
 
 // Boot Settings
-vm_boot_order = "disk,cdrom"
+vm_boot_order = "-"
 vm_boot_wait  = "5s"
 
 // Communicator Settings

--- a/builds/linux/debian/11/variables.pkr.hcl
+++ b/builds/linux/debian/11/variables.pkr.hcl
@@ -290,7 +290,7 @@ variable "common_http_port_max" {
 variable "vm_boot_order" {
   type        = string
   description = "The boot order for virtual machines devices."
-  default     = "disk,cdrom"
+  default     = "-"
 }
 
 variable "vm_boot_wait" {

--- a/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
@@ -35,7 +35,7 @@ iso_path = "iso/linux/debian"
 iso_file = "debian-12.4.0-amd64-netinst.iso"
 
 // Boot Settings
-vm_boot_order = "disk,cdrom"
+vm_boot_order = "-"
 vm_boot_wait  = "5s"
 
 // Communicator Settings

--- a/builds/linux/debian/12/variables.pkr.hcl
+++ b/builds/linux/debian/12/variables.pkr.hcl
@@ -290,7 +290,7 @@ variable "common_http_port_max" {
 variable "vm_boot_order" {
   type        = string
   description = "The boot order for virtual machines devices."
-  default     = "disk,cdrom"
+  default     = "-"
 }
 
 variable "vm_boot_wait" {


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Sets `vm_boot_order` = "-" to clear the boot order and remove the boot delay on Debian.

<!--
    Please provide a clear and concise description of the pull request.
-->

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #814 

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
