### PR TITLE
fix: re-add `ansible_username` and `ansible_key` variables for windows builds

### DIFF
--- a/builds/windows/desktop/10/variables.pkr.hcl
+++ b/builds/windows/desktop/10/variables.pkr.hcl
@@ -424,6 +424,20 @@ variable "communicator_timeout" {
   description = "The timeout for the communicator protocol."
 }
 
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
 // Provisioner Settings
 
 variable "scripts" {

--- a/builds/windows/desktop/11/variables.pkr.hcl
+++ b/builds/windows/desktop/11/variables.pkr.hcl
@@ -430,6 +430,20 @@ variable "communicator_timeout" {
   description = "The timeout for the communicator protocol."
 }
 
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
 // Provisioner Settings
 
 variable "scripts" {

--- a/builds/windows/server/2019/variables.pkr.hcl
+++ b/builds/windows/server/2019/variables.pkr.hcl
@@ -437,6 +437,20 @@ variable "communicator_timeout" {
   description = "The timeout for the communicator protocol."
 }
 
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
 // Provisioner Settings
 
 variable "scripts" {

--- a/builds/windows/server/2022/variables.pkr.hcl
+++ b/builds/windows/server/2022/variables.pkr.hcl
@@ -437,6 +437,20 @@ variable "communicator_timeout" {
   description = "The timeout for the communicator protocol."
 }
 
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
 // Provisioner Settings
 
 variable "scripts" {

--- a/builds/windows/server/2025/variables.pkr.hcl
+++ b/builds/windows/server/2025/variables.pkr.hcl
@@ -437,6 +437,20 @@ variable "communicator_timeout" {
   description = "The timeout for the communicator protocol."
 }
 
+// Ansible Credentials
+
+variable "ansible_username" {
+  type        = string
+  description = "The username for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
+variable "ansible_key" {
+  type        = string
+  description = "The public key for Ansible to login to the guest operating system."
+  sensitive   = true
+}
+
 // Provisioner Settings
 
 variable "scripts" {


### PR DESCRIPTION
# <!-- Intentionally left blank. -->

## Summary of Pull Request

Re-add `ansible_username` and `ansible_key` variables for Windows builds to remove validation warnings/errors.

## Type of Pull Request

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Might have snuck in via PR 801

Issue Number: N/A

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.
