### PR TITLE
chore(deps): bump debian from v12.4 to v12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Updates Rocky Linux 8 to 8.9 release. [GH-822](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/822)
 - Updates Oracle Linux 9 to 9.3 release. [GH-821](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/821)
 - Updates Oracle Linux 8 to 8.9 release. [GH-820](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/820)
-- Updates Debian 12 to 12.4 release. [GH-816](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/816)
+- Updates Debian 12 to 12.5 release. [GH-865](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/865)
 - Updates Debian 11 to 11.9 release. [GH-864](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/864)
 - Updates Ubuntu 22.04 to 22.04.4 release. [GH-863](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/863)
 - Updates AlmaLinux to upgrade the `almalinux-release` package during the build. [GH-](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/)

--- a/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
@@ -12,7 +12,7 @@ vm_guest_os_keyboard = "us"
 vm_guest_os_timezone = "UTC"
 vm_guest_os_family   = "linux"
 vm_guest_os_name     = "debian"
-vm_guest_os_version  = "12.4"
+vm_guest_os_version  = "12.5"
 
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "other5xLinux64Guest"
@@ -33,7 +33,7 @@ vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
 iso_path = "iso/linux/debian"
-iso_file = "debian-12.4.0-amd64-netinst.iso"
+iso_file = "debian-12.5.0-amd64-netinst.iso"
 
 // Boot Settings
 vm_boot_order = "-"


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Bumps Debian 12 from v12.4 to v12.5.


## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
