### PR TITLE
chore(deps): bump packer-plugin-vsphere from v1.2.1 to v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@
 
 - Updates `required_versions` for `packer` to `>= 1.10.0`.
   [#828](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/828)
-- Updates `required_plugins` for `packer-plugin-vsphere` to `>= 1.2.4`.
+- Updates `required_plugins` for `packer-plugin-vsphere` to `1.2.4`.
   [#824](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/824)
+  [#871](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/871)
 - Updates `required_plugins` for `ethanmdavidson/packer-plugin-git` to `>= 0.6.2`.
   [#868](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/868)
 - Updates `required_versions` for `terraform` to `>= 1.7.1`.

--- a/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/8/linux-almalinux.pkr.hcl
@@ -14,7 +14,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
+++ b/builds/linux/almalinux/9/linux-almalinux.pkr.hcl
@@ -14,7 +14,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/centos/7/linux-centos.pkr.hcl
+++ b/builds/linux/centos/7/linux-centos.pkr.hcl
@@ -14,7 +14,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/8-stream/linux-centos-stream.pkr.hcl
@@ -14,7 +14,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
+++ b/builds/linux/centos/9-stream/linux-centos-stream.pkr.hcl
@@ -14,7 +14,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/debian/11/linux-debian.pkr.hcl
+++ b/builds/linux/debian/11/linux-debian.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/debian/12/linux-debian.pkr.hcl
+++ b/builds/linux/debian/12/linux-debian.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/oracle/8/linux-oracle.pkr.hcl
+++ b/builds/linux/oracle/8/linux-oracle.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/oracle/9/linux-oracle.pkr.hcl
+++ b/builds/linux/oracle/9/linux-oracle.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/photon/4/linux-photon.pkr.hcl
+++ b/builds/linux/photon/4/linux-photon.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/photon/5/linux-photon.pkr.hcl
+++ b/builds/linux/photon/5/linux-photon.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/rhel/7/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/7/linux-rhel.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/rhel/9/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/9/linux-rhel.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/rocky/8/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/8/linux-rocky.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/rocky/9/linux-rocky.pkr.hcl
+++ b/builds/linux/rocky/9/linux-rocky.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/sles/15/linux-sles.pkr.hcl
+++ b/builds/linux/sles/15/linux-sles.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/linux/ubuntu/23-10/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/23-10/linux-ubuntu.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     ansible = {
       source  = "github.com/hashicorp/ansible"

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     git = {
       source  = "github.com/ethanmdavidson/git"

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     git = {
       source  = "github.com/ethanmdavidson/git"

--- a/builds/windows/server/2019/windows-server.pkr.hcl
+++ b/builds/windows/server/2019/windows-server.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     git = {
       source  = "github.com/ethanmdavidson/git"

--- a/builds/windows/server/2022/windows-server.pkr.hcl
+++ b/builds/windows/server/2022/windows-server.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     git = {
       source  = "github.com/ethanmdavidson/git"

--- a/builds/windows/server/2025/windows-server.pkr.hcl
+++ b/builds/windows/server/2025/windows-server.pkr.hcl
@@ -15,7 +15,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = ">= 1.2.4"
+      version = "1.2.4"
     }
     git = {
       source  = "github.com/ethanmdavidson/git"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Bumps Packer Plugin for vSphere (`hashicorp/packer-plugin-vsphere`) from v1.2.1 to v1.2.4.

Will provide the ability to use the `reattach_cdrom` option in v1.2.4.

Not that there is a regression in versions after v1.2.4 so the version is locked. This should be resolved in v1.2.7.

<!--
    Please provide a clear and concise description of the pull request.
-->

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
