### PR TITLE
fix: windows pwsh provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## v0.19.1
+
+> Release Date: 2024-04-15
+
+**Bug Fix**:
+
+- Removes the PowerShell provisioner for Windows 11 and 10 as it's not required after the transition
+  to Ansible. [#878](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/878)
+
 ## v0.19.0
 
 > Release Date: 2024-04-09

--- a/builds/windows/desktop/10/windows.pkr.hcl
+++ b/builds/windows/desktop/10/windows.pkr.hcl
@@ -286,12 +286,6 @@ build {
     "source.vsphere-iso.windows-desktop-ent",
   ]
 
-  provisioner "powershell" {
-    elevated_user     = var.build_username
-    elevated_password = var.build_password
-    inline            = var.inline
-  }
-
   provisioner "ansible" {
     user                   = var.build_username
     galaxy_file            = "${path.cwd}/ansible/windows-requirements.yml"

--- a/builds/windows/desktop/11/windows.pkr.hcl
+++ b/builds/windows/desktop/11/windows.pkr.hcl
@@ -290,12 +290,6 @@ build {
     "source.vsphere-iso.windows-desktop-ent",
   ]
 
-  provisioner "powershell" {
-    elevated_user     = var.build_username
-    elevated_password = var.build_password
-    inline            = var.inline
-  }
-
   provisioner "ansible" {
     user                   = var.build_username
     galaxy_file            = "${path.cwd}/ansible/windows-requirements.yml"


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Removes the PowerShell provisioner for Windows 11 and 10 as it's not required currently after the transition to Ansible.



## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #875

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
