### PR TITLE
fix: remove file for ubuntu cloud-init config

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -42,6 +42,8 @@
       loop:
         - /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
         - /etc/cloud/cloud.cfg.d/99-installer.cfg
+        - /etc/cloud/cloud.cfg.d/90-installer-network.cfg
+        - /etc/cloud/cloud-init.disabled
         - /etc/netplan/00-installer-config.yaml
       when: ansible_distribution == 'Ubuntu'
     - blockinfile:


### PR DESCRIPTION
# <!-- Intentionally left blank. -->

## Summary of Pull Request

Fix for ubuntu config:
- Remove `/etc/cloud/cloud-init.disabled` because it block the service start
- Remove `/etc/cloud/cloud.cfg.d/90-installer-network.cfg` because it block the network configuration

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
