### PR TITLE
fix: use `volume_group.name` as the volgroup name

### DIFF
--- a/builds/linux/almalinux/8/data/storage.pkrtpl.hcl
+++ b/builds/linux/almalinux/8/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/almalinux/9/data/storage.pkrtpl.hcl
+++ b/builds/linux/almalinux/9/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/centos/7/data/storage.pkrtpl.hcl
+++ b/builds/linux/centos/7/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/centos/9/data/storage.pkrtpl.hcl
+++ b/builds/linux/centos/9/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/fedora/40/data/storage.pkrtpl.hcl
+++ b/builds/linux/fedora/40/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/oracle/8/data/storage.pkrtpl.hcl
+++ b/builds/linux/oracle/8/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/oracle/9/data/storage.pkrtpl.hcl
+++ b/builds/linux/oracle/9/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/rhel/7/data/storage.pkrtpl.hcl
+++ b/builds/linux/rhel/7/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/rhel/8/data/storage.pkrtpl.hcl
+++ b/builds/linux/rhel/8/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/rhel/9/data/storage.pkrtpl.hcl
+++ b/builds/linux/rhel/9/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/rocky/8/data/storage.pkrtpl.hcl
+++ b/builds/linux/rocky/8/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/builds/linux/rocky/9/data/storage.pkrtpl.hcl
+++ b/builds/linux/rocky/9/data/storage.pkrtpl.hcl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.

--- a/tests/storage/templates/kickstart.pkrtpl
+++ b/tests/storage/templates/kickstart.pkrtpl
@@ -43,7 +43,7 @@ part
 %{ endfor ~}
 ### Create a logical volume management (LVM) group.
 %{ for index, volume_group in lvm ~}
-volgroup sysvg pv.${volume_group.name}
+volgroup ${volume_group.name} pv.${volume_group.name}
 
 ### Modify logical volume sizes for the virtual machine hardware.
 ### Create logical volumes.


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

<!--
    Please provide a clear and concise description of the pull request.
-->

Actually, it is impossible to use any other VolumeGroup name than **"sysvg"**.

If we follow the example from the [linux-storage.pkrvars.hcl.example](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/d2fde04a56867801bdaeb550e8aed3bf8e62af3f/builds/linux-storage.pkrvars.hcl.example#L56) file and change it to:

```
vm_disk_lvm = [
  {
    name : "any_other_name",
    partitions : [
```

The installation will generate a error mentioning that the VG doesn't exists.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
