### PR TITLE
fix: updated ubuntu cloud-init for 24.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## v0.21.0
+
+> Not Released
+
+**Bug Fix**:
+
+- Updates to debian.yml file to remove the disable flag on cloud-init for ubuntu 24.04 LTS version
+  [#940](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/940)
+
+
 ## v0.20.0
 
 > Release Date: 2024-05-29

--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -48,6 +48,12 @@
     - copy:
         content: 'datasource_list: [ VMware, OVF, None ]'
         dest: /etc/cloud/cloud.cfg.d/90_dpkg.cfg
+    - name: "Running cloud-init clean command"
+      command: sudo cloud-init clean --machine-id
+      become: yes
+      become_method: sudo
+      become_user: root
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 24
   when: enable_cloudinit == 'true'
 
 - name: "Replacing dhcp with static for Debian"


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request
Cloud-init was not starting as part of the deployment for ubuntu 24.04
<!--
    Please provide a clear and concise description of the pull request.
-->

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #939

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
