### PR TITLE
fix: skipped tasks due to wrong when condition 

### DIFF
--- a/ansible/roles/base/tasks/redhat.yml
+++ b/ansible/roles/base/tasks/redhat.yml
@@ -33,8 +33,8 @@
 # Tasks for updating the operating system and installing additional packages.
 - name: Updating the operating system and installing additional packages.
   when:
-    - ansible_distribution == 'Fedora'
-    - ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8
+    - (ansible_distribution == 'Fedora') or \
+      (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8)
   block:
     - name: Updating the operating system.
       ansible.builtin.dnf:
@@ -112,4 +112,3 @@
       ansible.builtin.yum:
         name: cloud-init
         state: latest # noqa package-latest
-


### PR DESCRIPTION
# <!-- Intentionally left blank. -->

## Summary of Pull Request

base_additional_packages are not installed when building a Rocky Linux because it doesnt validate the first condition (distribution == Fedora)

Ansible doc : You can use logical operators to combine conditions. When you have multiple conditions that all need to be true (that is, a logical and), you can specify them as a list.(https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html)


In version 0.20, a similar issue occurs, cloud-init installation is always skipped for Rocky
## Type of Pull Request


- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes #950

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
