### PR TITLE
fix: `rhsm_password` in clear text in /root/anaconda-ks.cfg and /root/original-ks.cfg

### DIFF
--- a/ansible/roles/clean/tasks/redhat.yml
+++ b/ansible/roles/clean/tasks/redhat.yml
@@ -88,3 +88,12 @@
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.bash_history"
     state: absent
+
+# Tasks to clean the install logs.
+- name: Cleaning the install logs.
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /root/anaconda-ks.cfg
+    - /root/original-ks.cfg


### PR DESCRIPTION

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

When building a RHEL template, credentials are displayed in clear text in kickstart files.
/root/anaconda-ks.cfg and /root/original-ks.cfg contains rhsm_username and rhsm_password in clear text.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.


Tested on RHEL9 and Rocky9. No risks to break: if the file is not present, Ansible will display the task as "OK".

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
