### PR TITLE
fix: rhel http and static ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   [#940](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/940)
 - Updates to `debian.yml` file to fix cloud-init install issue and additional package issue.
   [#944](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/944)
+- Fixes issue when using `http` data source with a static IP address and the kickstart file could not
+  be sent from Packer host.
+  [#959](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/959)
 
 **Enhancement**:
 

--- a/builds/linux/rhel/8/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/8/linux-rhel.pkr.hcl
@@ -76,10 +76,24 @@ locals {
       additional_packages = join(" ", var.additional_packages)
     })
   }
-  data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
-  vm_name             = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  http_ks_command = "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg"
+  http_ks_command_with_ip = format(
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg ip=%s::%s:%s:hostname:%s:none",
+    var.vm_ip_address != null ? var.vm_ip_address : "",
+    var.vm_ip_gateway != null ? var.vm_ip_gateway : "",
+    var.vm_ip_netmask != null ? var.vm_ip_netmask : "",
+    var.vm_network_device
+  )
+  data_source_command = var.common_data_source == "http" ? (
+    var.vm_ip_address != null && var.vm_ip_gateway != null && var.vm_ip_netmask != null ?
+    local.http_ks_command_with_ip :
+    local.http_ks_command
+    ) : (
+    var.common_data_source == "disk" ? "inst.ks=cdrom:/ks.cfg" : ""
+  )
+  vm_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source

--- a/builds/linux/rhel/9/linux-rhel.pkr.hcl
+++ b/builds/linux/rhel/9/linux-rhel.pkr.hcl
@@ -76,10 +76,24 @@ locals {
       additional_packages = join(" ", var.additional_packages)
     })
   }
-  data_source_command = var.common_data_source == "http" ? "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg" : "inst.ks=cdrom:/ks.cfg"
-  vm_name             = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
-  bucket_name         = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
-  bucket_description  = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+  http_ks_command = "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg"
+  http_ks_command_with_ip = format(
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg ip=%s::%s:%s:hostname:%s:none",
+    var.vm_ip_address != null ? var.vm_ip_address : "",
+    var.vm_ip_gateway != null ? var.vm_ip_gateway : "",
+    var.vm_ip_netmask != null ? var.vm_ip_netmask : "",
+    var.vm_network_device
+  )
+  data_source_command = var.common_data_source == "http" ? (
+    var.vm_ip_address != null && var.vm_ip_gateway != null && var.vm_ip_netmask != null ?
+    local.http_ks_command_with_ip :
+    local.http_ks_command
+    ) : (
+    var.common_data_source == "disk" ? "inst.ks=cdrom:/ks.cfg" : ""
+  )
+  vm_name            = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}-${local.build_version}"
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
 }
 
 //  BLOCK: source


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Fixes issue when using HTTP data source with a static IP address  and  the kickstart file could not be sent from Packer host.

<!--
    Please provide a clear and concise description of the pull request.
-->

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #955
Closes #958 

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
