### PR TITLE
refactor: update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,66 @@
 # Copyright 2023-2024 Broadcom. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+# Use the base Ubuntu devcontainer image.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
-# Install additional packages unavailable in the base image or as a feature.
-# Note: Unable to be installed used the "postCreateCommand" option.
+# Install additional packages.
 RUN apt-get update && \
-    apt-get install -y jq xorriso whois && \
-    apt-get autoremove -y && \
+    apt-get install -y apt-transport-https curl git jq software-properties-common unzip wget whois xorriso ca-certificates
+
+RUN update-ca-certificates
+
+# Install Packer using the latest release.
+RUN PACKER_VERSION=$(curl -s https://api.github.com/repos/hashicorp/packer/releases/latest | jq -r .tag_name | sed 's/^v//') && \
+    echo "Latest Packer Version: ${PACKER_VERSION}." && \
+    PACKER_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" && \
+    echo "Downloading Packer from ${PACKER_URL}..." && \
+    wget --no-check-certificate -q -O packer_${PACKER_VERSION}_linux_amd64.zip ${PACKER_URL} || { echo "Error: Failed to download."; wget --no-check-certificate ${PACKER_URL}; exit 1; } && \
+    echo "Installing Packer ${PACKER_VERSION}..." && \
+    unzip -o packer_${PACKER_VERSION}_linux_amd64.zip || { echo "Failed to unzip the download."; exit 1; } && \
+    mv packer /usr/local/bin/ || { echo "Error: Failed to move binary."; exit 1; } && \
+    rm packer_${PACKER_VERSION}_linux_amd64.zip || { echo "Error: Failed to remove download."; exit 1; }
+
+# Install Terraform using the latest release.
+RUN TERRAFORM_VERSION=$(curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | jq -r .tag_name | sed 's/^v//') && \
+    echo "Latest Terraform Version: ${TERRAFORM_VERSION}." && \
+    TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    echo "Downloading Terraform from ${TERRAFORM_URL}..." && \
+    wget --no-check-certificate -q -O terraform_${TERRAFORM_VERSION}_linux_amd64.zip ${TERRAFORM_URL} || { echo "Error: Failed to download."; wget --no-check-certificate ${TERRAFORM_URL}; exit 1; } && \
+    echo "Installing Terraform ${TERRAFORM_VERSION}..." && \
+    unzip -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip || { echo "Error: Failed to unzip the  download."; exit 1; } && \
+    mv terraform /usr/local/bin/ || { echo "Error: Failed to the move binary."; exit 1; } && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip || { echo "Error: Failed to remove download."; exit 1; }
+
+# Install Gomplate using the latest release.
+RUN GOMPLATE_VERSION=$(wget --no-check-certificate -q -O - https://api.github.com/repos/hairyhenderson/gomplate/releases/latest | jq -r .tag_name | sed 's/^v//') && \
+    echo "Latest Gomplate Version: ${GOMPLATE_VERSION}." && \
+    GOMPLATE_URL="https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64" && \
+    echo "Downloading Gomplate ${GOMPLATE_VERSION}..." && \
+    wget --no-check-certificate -q -O gomplate_linux-amd64 ${GOMPLATE_URL} || { echo "Error: Failed to download."; exit 1; } && \
+    echo "Installing Gomplate ${GOMPLATE_VERSION}..." && \
+    chmod +x gomplate_linux-amd64 && \
+    mv gomplate_linux-amd64 /usr/local/bin/gomplate || { echo "Error: Failed to move binary."; exit 1; }
+
+# Install PowerShell using the latest release.
+RUN PWSH_VERSION=$(wget --no-check-certificate -q -O - https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r .tag_name | sed 's/^v//') && \
+    echo "Latest PowerShell Version: ${PWSH_VERSION}." && \
+    PWSH_DEB_URL=$(wget --no-check-certificate -q -O - https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r '.assets[] | select(.name | endswith("amd64.deb")).browser_download_url' | head -n 1) && \
+    echo "Downloading PowerShell ${PWSH_VERSION}..." && \
+    wget --no-check-certificate -q $PWSH_DEB_URL || { echo "Error: Failed to download."; exit 1; } && \
+    echo "Installing PowerShell ${PWSH_VERSION}..." && \
+    dpkg -i $(basename $PWSH_DEB_URL) || { echo "Error: Failed to install PowerShell."; exit 1; } && \
+    rm $(basename $PWSH_DEB_URL) || { echo "Error: Failed to remove download."; exit 1; }
+
+# Install Python3 and Ansible.
+RUN add-apt-repository --yes --update ppa:ansible/ansible && \
+    apt-get update && \
+    apt-get install -y python3 python3-pip ansible
+
+# Cleanup.
+RUN apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Set PATH
+ENV PATH="$HOME/.local/bin:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "features": {
-    "ghcr.io/devcontainers/features/powershell:1": {},
-    "ghcr.io/devcontainers-contrib/features/ansible:2": {},
-    "ghcr.io/devcontainers-contrib/features/packer-asdf:2": {},
-    "ghcr.io/devcontainers-contrib/features/terraform-asdf:2": {},
-    "ghcr.io/gickis/devcontainer-features/gomplate:1": {}
-  },
+  "features": {},
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,5 +59,8 @@
     "editor.formatOnType": true,
     "editor.trimAutoWhitespace": true,
     "editor.wordWrap": "off"
+  },
+  "[dockerfile]": {
+    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
   }
 }


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Refactors the devcontainer.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [x] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #954

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

```console
 => => sha256:cfea65fda5e41dcbd5bee2aecb5c56254a1e77a5f09c877 408B / 408B  0.1s
[+] Building 416.9s (4/12)                               docker:rancher-desktop
 => => sha256:8dcc51a117710d9a11b619d69ae356c76b130eb650a 9.66kB / 9.66kB  0.0s
 => => sha256:cfea65fda5e41dcbd5bee2aecb5c56254a1e77a5f09c877 408B / 408B  0.1s
[+] Building 417.1s (4/12)                               docker:rancher-desktop
 => => sha256:8dcc51a117710d9a11b619d69ae356c76b130eb650a 9.66kB / 9.66kB  0.0s
 => => sha256:cfea65fda5e41dcbd5bee2aecb5c56254a1e77a5f09c877 408B / 408B  0.1s
 ....
 => => extracting sha256:182ee6259221e89018978eb318709fd9f1885fc9ffafcc9  17.2s
 => [dev_container_auto_added_stage_label 2/9] RUN apt-get update &&     668.0s
 => [dev_container_auto_added_stage_label 3/9] RUN update-ca-certificates  1.7s
 => [dev_container_auto_added_stage_label 4/9] RUN PACKER_VERSION=$(curl   7.9s
 => [dev_container_auto_added_stage_label 5/9] RUN TERRAFORM_VERSION=$(c  10.1s
 => [dev_container_auto_added_stage_label 6/9] RUN GOMPLATE_VERSION=$(wg  14.8s
 => [dev_container_auto_added_stage_label 7/9] RUN PWSH_VERSION=$(wget -  21.0s
 => [dev_container_auto_added_stage_label 8/9] RUN add-apt-repository -  564.5s
 => [dev_container_auto_added_stage_label 9/9] RUN apt-get autoremove -y   2.9s
 => exporting to image                                                     2.7s
 => => exporting layers                                                    2.7s
```

![image](https://github.com/user-attachments/assets/a239c782-c331-4912-b8c3-768f85f94c53)

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
