### PR TITLE
fix: set `GRUB_CMDLINE_LINUX_DEFAULT`

### DIFF
--- a/builds/linux/ubuntu/20-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu/20-04-lts/data/user-data.pkrtpl.hcl
@@ -43,3 +43,5 @@ ${network}
     - sed -i -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config
     - echo '${build_username} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/${build_username}
     - curtin in-target --target=/target -- chmod 440 /etc/sudoers.d/${build_username}
+    - curtin in-target --target=/target -- sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*$/GRUB_CMDLINE_LINUX_DEFAULT=""/' /etc/default/grub
+    - curtin in-target --target=/target -- update-grub

--- a/builds/linux/ubuntu/22-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu/22-04-lts/data/user-data.pkrtpl.hcl
@@ -43,3 +43,5 @@ ${network}
     - sed -i -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config
     - echo '${build_username} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/${build_username}
     - curtin in-target --target=/target -- chmod 440 /etc/sudoers.d/${build_username}
+    - curtin in-target --target=/target -- sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*$/GRUB_CMDLINE_LINUX_DEFAULT=""/' /etc/default/grub
+    - curtin in-target --target=/target -- update-grub

--- a/builds/linux/ubuntu/24-04-lts/data/user-data.pkrtpl.hcl
+++ b/builds/linux/ubuntu/24-04-lts/data/user-data.pkrtpl.hcl
@@ -43,3 +43,5 @@ ${network}
     - sed -i -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config
     - echo '${build_username} ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/${build_username}
     - curtin in-target --target=/target -- chmod 440 /etc/sudoers.d/${build_username}
+    - curtin in-target --target=/target -- sed -i 's/^GRUB_CMDLINE_LINUX_DEFAULT=.*$/GRUB_CMDLINE_LINUX_DEFAULT=""/' /etc/default/grub
+    - curtin in-target --target=/target -- update-grub


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

I ran into https://github.com/vmware-samples/packer-examples-for-vsphere/issues/981 today, it seems to come from `GRUB_CMDLINE_LINUX_DEFAULT` being set on `packer` template provisioning via `cloud-init` installer.
It is set by packer `boot_command` on kernel cmdline arguments and tell `cloud-init` to use a specific DataSource (`nocloud-net` or `nocloud`) and the installer persists these arguments on grub configuration in `/etc/default/grub`.
It it the reason why `cloud-init` does not read `VMware` DataSource.

I ended up with this Pull Request to restablish an empty `GRUB_CMDLINE_LINUX_DEFAULT` as `late_command`

It works on my side

Tested on `Ubuntu 22.04 LTS`

Hope it'll help someone.
<!--
    Please provide a clear and concise description of the pull request.
-->

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Closes #981

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
