### PR TITLE
feat: add confirmation before overwriting configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Reestablished an empty `GRUB_CMDLINE_LINUX_DEFAULT` as `late_command` for Ubuntu.
   [#982](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/982)
 
+**Enhancement**:
+
+- Adds confirmation before overwriting existing configuration files.
+  [#987](https://github.com/vmware-samples/packer-examples-for-vsphere/pull/987)
+
 **Chore**:
 
 - Updates Debian 11 to 11.11 release.

--- a/config.sh
+++ b/config.sh
@@ -36,7 +36,7 @@ done
 echo
 echo "> Renaming the example input variables..."
 for file in "${CONFIG_PATH}"/*.pkrvars.hcl.example; do
-    mv -- "${file}" "${file%.example}"
+    mv -i -- "${file}" "${file%.example}"
 done
 
 echo


### PR DESCRIPTION
## Summary of Pull Request

Adds confirmation before overwriting existing configuration files.

When using `config.sh` on a already setup system (for example to refresh with the current templates) it will overwrite all the files (even the ones customized) without confirmation.

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [x] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.

## Testing

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
