### PR TITLE
Fix: Update windows-vmtools.ps1 for latest vmware tools

### DIFF
--- a/scripts/windows/windows-vmtools.ps1
+++ b/scripts/windows/windows-vmtools.ps1
@@ -36,7 +36,7 @@ Set-Location E:
 # Installation Attempt
 
 Write-Output "Installing VMware Tools..."
-Start-Process "setup64.exe" -ArgumentList '/s /v "/qb REBOOT=R"' -Wait
+Start-Process "setup.exe" -ArgumentList '/S /v "/qn REBOOT=R"' -Wait
 
 # Check to see if the 'VMTools' service is in a 'Running' state.
 
@@ -78,10 +78,10 @@ if (-not $Running) {
   # Installation Attempt
 
   Write-Output "Reintalling VMware Tools..."
-  Start-Process "setup64.exe" -ArgumentList '/s /v "/qb REBOOT=R"' -Wait
+  Start-Process "setup.exe" -ArgumentList '/S /v "/qn REBOOT=R"' -Wait
 
   # Check to see if the 'VMTools' service is in a 'Running' state.
-
+}
 Write-Output "Checking VMware Tools service status..."
 
 $iRepeat = 0


### PR DESCRIPTION
Updated for latest vmware tools, also fixed a missing } which caused it to fail on Windows 2025

<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

Changed powershell script for vmware tools on windows to work with latest tools.

## Type of Pull Request



- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

  - Resolves #997

Issue Number: N/A

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

If you're running an older vmware environment this will break the vmware tools install. Other than that, no breaking changes.