### PR TITLE
fix unsupported distro issue - Centos Stream - Ref #996

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -780,7 +780,7 @@ select_build() {
     fi
 
     case "$dist" in
-    "Debian" | "Ubuntu Server" | "AlmaLinux OS" | "Rocky Linux" | "Oracle Linux" | "CentOS" | "Fedora Server")
+    "Debian" | "Ubuntu Server" | "AlmaLinux OS" | "Rocky Linux" | "Oracle Linux" | "CentOS Stream" | "Fedora Server")
         var_files=("vsphere_vars" "build_vars" "ansible_vars" "proxy_vars" "common_vars" "network_vars" "storage_vars" "BUILD_VARS")
         validate_linux_username "$config_path/build.pkrvars.hcl"
         printf "Starting the build of %s %s...\n\n" "$dist" "$version"


### PR DESCRIPTION
CentOS did not match the "string" from jq output.  
Needed to be "CentOS Stream"

Resolves #996 

- [X] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues
Closes #996

## Test and Documentation Coverage

- [X] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

