### PR TITLE
fix: update winre partition size

### DIFF
--- a/builds/windows/server/2025/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/server/2025/data/autounattend.pkrtpl.hcl
@@ -28,7 +28,7 @@
                   <CreatePartition wcm:action="add">
                      <Order>1</Order>
                      <Type>Primary</Type>
-                     <Size>550</Size>
+                     <Size>800</Size>
                   </CreatePartition>
                   <!-- System partition (ESP) -->
                   <CreatePartition wcm:action="add">


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

This pull request includes a change to the partition size configuration in the `autounattend.pkrtpl.hcl` file for Windows Server 2025 builds. The size of a primary partition has been increased to accommodate additional storage requirements.

* [`builds/windows/server/2025/data/autounattend.pkrtpl.hcl`](diffhunk://#diff-53e6cad760880317df5ae9334f276ce36a83fc9582cd109ce8775f25a64d8e39L31-R31): Updated the partition size from `550` to `800`.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Resolves #1043

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
