### PR TITLE
fix: correct Debian 11 amd64 links from arm64 to amd64

### DIFF
--- a/project.json
+++ b/project.json
@@ -64,9 +64,9 @@
                                 "architectures": [
                                     {
                                         "architecture": "amd64",
-                                        "download_link": "https://cdimage.debian.org/cdimage/archive/11.11.0/arm64/iso-cd/debian-11.11.0-arm64-netinst.iso",
+                                        "download_link": "https://cdimage.debian.org/cdimage/archive/11.11.0/amd64/iso-cd/debian-11.11.0-amd64-netinst.iso",
                                         "checksum_algorithm": "sha256",
-                                        "checksum": "https://cdimage.debian.org/cdimage/archive/11.11.0/arm64/iso-cd/SHA256SUMS"
+                                        "checksum": "https://cdimage.debian.org/cdimage/archive/11.11.0/amd64/iso-cd/SHA256SUMS"
                                     }
                                 ],
                                 "build_files": [


### PR DESCRIPTION
## Summary of Pull Request

This PR fixes the download links for Debian 11 which incorrectly point to arm64 instead of amd64 as specified by the architecture property.

## Type of Pull Request

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes: #1072 

## Test and Documentation Coverage

- [ ] ~~Tests have been completed.~~
- [ ] ~~Documentation has been added or updated.~~

## Breaking Changes?

- [ ] ~~Yes, there are breaking changes.~~
- [x] No, there are no breaking changes.