### PR TITLE
fix: add -L option to curl commands for handling redirects

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -424,7 +424,7 @@ select_download() {
     if [[ "$dist" == *"Windows"* ]]; then
         download_link=$(jq -r --arg os "$os" --arg dist "$dist" --arg version "$version" --arg arch "$arch" '.os[] | select(.name == $os) | .types[] | select(.description == $dist) | .versions[$version][] | .architectures[] | select(.architecture == $arch) | .download_link' $json_path)
         # Validate the download link
-        if curl --output /dev/null --silent --head --fail "$download_link"; then
+        if curl -L --output /dev/null --silent --head --fail "$download_link"; then
             download_dir="$(echo "${iso_base_path}/${os}/${dist}/${version}/${arch}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
         else
             printf "\n\n"
@@ -469,7 +469,7 @@ select_download() {
 
         # Set the download command based on the availability of curl or wget.
         if command -v curl >/dev/null 2>&1; then
-            download_command="curl -o"
+            download_command="curl -L -o"
         elif command -v wget >/dev/null 2>&1; then
             download_command="wget -q -O "
         fi
@@ -579,7 +579,7 @@ select_download() {
 
         # Set the download command based on the availability of curl or wget.
         if command -v curl >/dev/null 2>&1; then
-            download_command="curl -o"
+            download_command="curl -L -o"
         elif command -v wget >/dev/null 2>&1; then
             download_command="wget -q -O"
         fi
@@ -599,7 +599,7 @@ select_download() {
         dist_name=$(jq -r --arg os "$os" --arg desc "$description" '.os[] | select(.name == $os) | .distributions[] | select(.description == $desc) | .name' $json_path)
         download_link=$(jq -r --arg os "$os" --arg dist "$dist" --arg version "$version" --arg arch "$arch" '.os[] | select(.name == $os) | .distributions[] | select(.description == $dist) | .versions | to_entries[] | .value[] | select(.version == $version) | .architectures[] | select(.architecture == $arch) | .download_link' $json_path)
         # Validate the download link
-        if curl --output /dev/null --silent --head --fail "$download_link"; then
+        if curl -L --output /dev/null --silent --head --fail "$download_link"; then
             download_dir="$(echo "${iso_base_path}/${os}/${dist}/${version}/${arch}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
         else
             printf "\n"
@@ -645,7 +645,7 @@ select_download() {
 
         # Set the download command based on the availability of curl or wget.
         if command -v curl >/dev/null 2>&1; then
-            download_command="curl -o"
+            download_command="curl -L -o"
         elif command -v wget >/dev/null 2>&1; then
             download_command="wget -q -O"
         fi
@@ -716,7 +716,7 @@ download_checksum_file() {
         # Set the download command based on the availability of curl or wget.
         download_command=""
         if command -v curl >/dev/null 2>&1; then
-            download_command="curl -o"
+            download_command="curl -L -o"
         elif command -v wget >/dev/null 2>&1; then
             download_command="wget -q -O "
         fi


### PR DESCRIPTION
## Summary of Pull Request

This PR fixes/improves the download script to enable following redirects.

Previously, the redirect response was being downloaded instead of the iso file, e.g.:

```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://laotzu.ftp.acc.umu.se/cdimage/archive/12.12.0/amd64/iso-cd/debian-12.12.0-amd64-netinst.iso">here</a>.</p>
<hr>
<address>Apache/2.4.63 (Unix) Server at cdimage.debian.org Port 443</address>
</body></html>
```

## Type of Pull Request

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes: #1071 

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] ~~Documentation has been added or updated.~~

## Breaking Changes?

- [ ] ~~Yes, there are breaking changes.~~
- [x] No, there are no breaking changes.
