### PR TITLE
chore(deps): bump Debian version to 12.12

### DIFF
--- a/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
+++ b/builds/linux/debian/12/linux-debian.pkrvars.hcl.example
@@ -9,7 +9,7 @@
 
 // Guest Operating System Metadata
 vm_guest_os_name     = "debian"
-vm_guest_os_version  = "12.10"
+vm_guest_os_version  = "12.12"
 
 // Virtual Machine Guest Operating System Setting
 vm_guest_os_type = "other5xLinux64Guest"
@@ -19,6 +19,6 @@ vm_firmware = "efi-secure"
 
 // Removable Media Settings
 iso_datastore_path       = "iso/linux/debian/12/amd64"
-iso_content_library_item = "debian-12.11.0-amd64-netinst"
-iso_file                 = "debian-12.11.0-amd64-netinst.iso"
+iso_content_library_item = "debian-12.12.0-amd64-netinst"
+iso_file                 = "debian-12.12.0-amd64-netinst.iso"
 

--- a/project.json
+++ b/project.json
@@ -39,9 +39,9 @@
                                 "architectures": [
                                     {
                                         "architecture": "amd64",
-                                        "download_link": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.11.0-amd64-netinst.iso",
+                                        "download_link": "https://cdimage.debian.org/cdimage/archive/12.12.0/amd64/iso-cd/debian-12.12.0-amd64-netinst.iso",
                                         "checksum_algorithm": "sha256",
-                                        "checksum": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS"
+                                        "checksum": "https://cdimage.debian.org/cdimage/archive/12.12.0/amd64/iso-cd/SHA256SUMS"
                                     }
                                 ],
                                 "build_files": [


### PR DESCRIPTION
## Summary of Pull Request

Bump Debian version to 12.12 - also partially a fix due to the `current` now being for Debian 13, making the current URL invalid.

Also fixes a mismatch between the current version and the metadata.

## Type of Pull Request

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Issue Number: N/A

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] ~~Documentation has been added or updated.~~

## Breaking Changes?

- [ ] ~~Yes, there are breaking changes.~~
- [x] No, there are no breaking changes.
