### PR TITLE
chore(deps): bump `chocolatey` to 2.6.0 and trim packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   [#1101](https://github.com/vmware/packer-examples-for-vsphere/pull/1104)
 - Updates Ansible `community.general` collection to `12.4.0`.
   [#1108](https://github.com/vmware/packer-examples-for-vsphere/pull/1108)
+- Updates `chocolatey` to `2.6.0`.
+  [#1109](https://github.com/vmware/packer-examples-for-vsphere/pull/1109)
 - Updates `required_versions` for `packer` to `>= 1.15.0`.
   [#1106](https://github.com/vmware/packer-examples-for-vsphere/pull/1107)
 - Updates `required_plugins` for `packer-plugin-vsphere` to `>= 2.1.1`.
@@ -77,6 +79,8 @@
 - Removes the use of `awk` commands that printed the installed versions of
   supporting components.
   [#1089](https://github.com/vmware/packer-examples-for-vsphere/pull/1089)
+- Removes additional packages from the `chocolatey` package lists.
+  [#1109](https://github.com/vmware/packer-examples-for-vsphere/pull/1109)
 - Eliminates the outer `when: enable_cloudinit == 'true''` condition from
   the configuration task, as the inner conditions are sufficient for task
   execution.


### PR DESCRIPTION
<!--

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/packer-examples-for-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

-->

# <!-- Intentionally left blank. -->

## Summary of Pull Request

- Bump `chocolatey` to from 1.4.0 to 2.6.0.
- Trim additional packages from the chocolatey package lists.

## Type of Pull Request

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [x] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

<!--
  Is this related to any GitHub issue(s)?

  For example:
  - Resolves #1234
-->

Issue Number: N/A

## Test and Documentation Coverage

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [x] Tests have been completed.
- [x] Documentation has been added or updated.

## Breaking Changes?

<!--
    Please check the one that applies to this pull request using "[x]".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
