### PR TITLE
fix(ubuntu): replace deprecated gateway4 with routes in cloud-init network config

### DIFF
--- a/builds/linux/ubuntu/22-04-lts/data/network.pkrtpl.hcl
+++ b/builds/linux/ubuntu/22-04-lts/data/network.pkrtpl.hcl
@@ -7,7 +7,9 @@
           dhcp4: false
           addresses:
             - ${ip}/${netmask}
-          gateway4: ${gateway}
+          routes:
+            - to: default
+              via: ${gateway}
           nameservers:
             addresses:
 %{ for item in dns ~}

--- a/builds/linux/ubuntu/24-04-lts/data/network.pkrtpl.hcl
+++ b/builds/linux/ubuntu/24-04-lts/data/network.pkrtpl.hcl
@@ -7,7 +7,9 @@
           dhcp4: false
           addresses:
             - ${ip}/${netmask}
-          gateway4: ${gateway}
+          routes:
+            - to: default
+              via: ${gateway}
           nameservers:
             addresses:
 %{ for item in dns ~}


### PR DESCRIPTION
## Summary of Pull Request

Replace deprecated `gateway4` field with `routes` syntax in Ubuntu cloud-init network template.
The `gateway4` property has been deprecated in cloud-init/netplan and causes Ubuntu VMs to fail to acquire an IP address during provisioning. This replaces it with the recommended `routes` block using `to: default` and `via: <gateway>`.

[Link](https://github.com/canonical/cloud-init/pull/1794)

## Type of Pull Request

- [x] This is a bugfix. `type/bug`
- [ ] This is an enhancement or feature. `type/feature` or `type/enhancement`
- [ ] This is a documentation update. `type/docs`
- [ ] This is a refactoring update. `type/refactor`
- [ ] This is a chore. `type/chore`
- [ ] This is something else.
      Please describe:

## Related to Existing Issues

Closes #1112

## Test and Documentation Coverage

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

## Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.